### PR TITLE
feat: implement WebSocket IM service frontend-backend integration

### DIFF
--- a/apps/im/api/internal/logic/getconversationslogic.go
+++ b/apps/im/api/internal/logic/getconversationslogic.go
@@ -42,8 +42,12 @@ func (l *GetConversationsLogic) GetConversations(req *types.GetConversationsReq)
 	}
 
 	// 会话列表需要展示最后一条聊天信息,需要从会话详情中获取会话last_msg
+	// 过滤掉 isShow=false 的已删除会话
 	conversations := make(map[string]types.Conversation, len(res.ConversationList))
 	for k, v := range res.ConversationList {
+		if !v.IsShow {
+			continue
+		}
 		var message types.ChatLog
 		if v.Msg != nil {
 			message = types.ChatLog{

--- a/apps/im/api/internal/types/types.go
+++ b/apps/im/api/internal/types/types.go
@@ -15,11 +15,11 @@ type ChatLog struct {
 }
 
 type ChatLogReq struct {
-	MsgId          string `json:"msgId"`
-	ConversationId string `json:"conversationId"`
-	StartSendTime  int64  `json:"startSendTime,omitempty"`
-	EndSendTime    int64  `json:"endSendTime,omitempty"`
-	Count          int64  `json:"count,omitempty"`
+	MsgId          string `form:"msgId,optional"`
+	ConversationId string `form:"conversationId"`
+	StartSendTime  int64  `form:"startSendTime,optional"`
+	EndSendTime    int64  `form:"endSendTime,optional"`
+	Count          int64  `form:"count,optional"`
 }
 
 type ChatLogResp struct {
@@ -27,12 +27,12 @@ type ChatLogResp struct {
 }
 
 type Conversation struct {
-	ConversationId string  `json:"conversationId,omitempty"`
-	ChatType       int32   `json:"chatType,omitempty"` // 修正字段名统一小写
-	IsShow         bool    `json:"isShow,omitempty"`
-	Seq            int64   `json:"seq,omitempty"`
-	Read           int32   `json:"read"`
-	Msg            ChatLog `json:"message, optional"`
+	ConversationId string  `json:"conversationId,optional,omitempty"`
+	ChatType       int32   `json:"chatType,optional,omitempty"`
+	IsShow         bool    `json:"isShow,optional,omitempty"`
+	Seq            int64   `json:"seq,optional,omitempty"`
+	Read           int32   `json:"read,optional,omitempty"`
+	Msg            ChatLog `json:"message,optional,omitempty"`
 }
 
 type GetChatLogReadRecordsReq struct {

--- a/apps/im/rpc/internal/logic/getchatloglogic.go
+++ b/apps/im/rpc/internal/logic/getchatloglogic.go
@@ -28,29 +28,39 @@ func NewGetChatLogLogic(ctx context.Context, svcCtx *svc.ServiceContext) *GetCha
 // GetChatLog 获取会话记录
 // 依据传递的数据时间点获取
 func (l *GetChatLogLogic) GetChatLog(in *im.GetChatLogReq) (*im.GetChatLogResp, error) {
-	// 根据id查询
+	// msgId 作为游标：查该消息的 sendTime，然后查更早的 count 条
 	if in.MsgId != "" {
 		chatlog, err := l.svcCtx.ChatLogModel.FindOne(l.ctx, in.MsgId)
 		if err != nil {
 			return nil, errors.Wrapf(xerr.NewDBErr(), "find chatLog by msgId err %v, req %v", err, in.MsgId)
 		}
 
-		return &im.GetChatLogResp{
-			List: []*im.ChatLog{{
-				Id:             chatlog.ID.Hex(),
-				ConversationId: chatlog.ConversationId,
-				SendId:         chatlog.SendId,
-				RecvId:         chatlog.RecvId,
-				MsgType:        int32(chatlog.MsgType),
-				MsgContent:     chatlog.MsgContent,
-				ChatType:       int32(chatlog.ChatType),
-				SendTime:       chatlog.SendTime,
-				ReadRecords:    chatlog.ReadRecords,
-			}},
-		}, nil
+		// 用该消息的 sendTime - 1 作为 endSendTime，查更早的消息
+		endTime := chatlog.SendTime - 1
+		data, err := l.svcCtx.ChatLogModel.ListBySendTime(l.ctx, in.ConversationId, in.StartSendTime, endTime, in.Count)
+		if err != nil {
+			return nil, errors.Wrapf(xerr.NewDBErr(), "find chatLog list by cursor err %v", err)
+		}
+
+		res := make([]*im.ChatLog, 0, len(data))
+		for _, datum := range data {
+			res = append(res, &im.ChatLog{
+				Id:             datum.ID.Hex(),
+				ConversationId: datum.ConversationId,
+				SendId:         datum.SendId,
+				RecvId:         datum.RecvId,
+				MsgType:        int32(datum.MsgType),
+				MsgContent:     datum.MsgContent,
+				ChatType:       int32(datum.ChatType),
+				SendTime:       datum.SendTime,
+				ReadRecords:    datum.ReadRecords,
+			})
+		}
+
+		return &im.GetChatLogResp{List: res}, nil
 	}
 
-	// 根据会话和时间范围查询
+	// 无游标：根据会话和时间范围查询
 	data, err := l.svcCtx.ChatLogModel.ListBySendTime(l.ctx, in.ConversationId, in.StartSendTime, in.EndSendTime, in.Count)
 	if err != nil {
 		return nil, errors.Wrapf(xerr.NewDBErr(), "find chatLog list by SendTime err %v, req %v", err, in)

--- a/apps/im/ws/internal/handler/auth.go
+++ b/apps/im/ws/internal/handler/auth.go
@@ -25,6 +25,12 @@ func NewJwtAuto(srvCtx *svc.ServiceContext) *JwtAuto {
 }
 
 func (auto *JwtAuto) Auth(w http.ResponseWriter, r *http.Request) bool {
+	// 浏览器原生 WebSocket 不支持自定义 Header，
+	// 需要支持从 URL 查询参数 ?token=xxx 读取 JWT
+	if qToken := r.URL.Query().Get("token"); qToken != "" && r.Header.Get("Authorization") == "" {
+		r.Header.Set("Authorization", "Bearer "+qToken)
+	}
+
 	tok, err := auto.parser.ParseToken(r, auto.srvCtx.Config.JwtAuth.AccessSecret, "")
 	fmt.Println("token:", tok)
 	if err != nil {

--- a/apps/im/ws/internal/handler/push/pusher.go
+++ b/apps/im/ws/internal/handler/push/pusher.go
@@ -46,6 +46,7 @@ func single(srv *websocket.Server, data *ws.Push, recvId string) error {
 	sendMsg := websocket.NewMessage(
 		data.SendId, &ws.Chat{
 			ConversationId: data.ConversationId,
+			ChatType:       data.ChatType,
 			RecvId:         data.RecvId,
 			SendId:         data.SendId,
 			SendTime:       data.SendTime,

--- a/apps/im/ws/websocket/server.go
+++ b/apps/im/ws/websocket/server.go
@@ -74,7 +74,9 @@ type Server struct {
 func NewServer(addr string, opt ...Options) *Server {
 	return &Server{
 		addr:           addr,
-		upGrader:       websocket.Upgrader{},
+		upGrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
 		routes:         make(map[string]HandlerFunc),
 		user2Conn:      make(map[string]*Conn),
 		conn2User:      make(map[*Conn]string),
@@ -195,9 +197,8 @@ func (s *Server) readAck(conn *Conn) {
 		// 这里相当于自旋
 		if len(conn.readMessages) == 0 {
 			conn.messageMu.Unlock()
-			// 没有消息进来的时候
-			// 没有消息可以睡眠100 毫秒 -- 目的是让程序缓一缓
-			time.Sleep(3 * time.Second)
+			// 队列为空时短暂等待，避免 CPU 空转
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
@@ -280,8 +281,8 @@ func (s *Server) readAck(conn *Conn) {
 					continue
 				}
 			}
-			// 没有超时，我们让程序等等
-			time.Sleep(3 * time.Second)
+			// 等待客户端 ACK 确认，短轮询
+			time.Sleep(100 * time.Millisecond)
 		}
 	}
 }

--- a/apps/im/ws/ws/ws.go
+++ b/apps/im/ws/ws/ws.go
@@ -4,68 +4,68 @@ import "github.com/iceymoss/go-hichat-api/pkg/constants"
 
 type Msg struct {
 	// 消息类型
-	constants.MType `mapstructure:"mType"`
+	constants.MType `json:"mType" mapstructure:"mType"`
 
 	// 消息内容
-	Content string `mapstructure:"content"`
+	Content string `json:"content" mapstructure:"content"`
 
 	// 已读记录 key为消息id、value为消息值
-	ReadRecords map[string]string `mapstructure:"readRecords"`
+	ReadRecords map[string]string `json:"readRecords" mapstructure:"readRecords"`
 }
 
 // Chat 聊天会话， message 结构中的data字段
 type Chat struct {
 	// 会话id
-	ConversationId string `mapstructure:"conversationId"`
+	ConversationId string `json:"conversationId" mapstructure:"conversationId"`
 
 	// 聊天类型
-	constants.ChatType `mapstructure:"chatType"`
+	constants.ChatType `json:"chatType" mapstructure:"chatType"`
 
 	// 发送者
-	SendId string `mapstructure:"sendId"`
+	SendId string `json:"sendId" mapstructure:"sendId"`
 
 	// 接收者
-	RecvId string `mapstructure:"recvId"`
+	RecvId string `json:"recvId" mapstructure:"recvId"`
 
 	// 发送时间
-	SendTime int64 `mapstructure:"sendTime"`
+	SendTime int64 `json:"sendTime" mapstructure:"sendTime"`
 
 	// 发送内容
-	Msg `mapstructure:"msg"`
+	Msg `json:"msg" mapstructure:"msg"`
 }
 
 type Push struct {
 	// 会话id
-	ConversationId string `mapstructure:"conversationId"`
+	ConversationId string `json:"conversationId" mapstructure:"conversationId"`
 
 	// 聊天类型：1. 私聊、2. 群聊
-	constants.ChatType `mapstructure:"chatType"`
+	constants.ChatType `json:"chatType" mapstructure:"chatType"`
 
 	// 发送者
-	SendId string `mapstructure:"sendId"`
+	SendId string `json:"sendId" mapstructure:"sendId"`
 
-	RecvIdList []string `mapstructure:"recvIdList"`
+	RecvIdList []string `json:"recvIdList" mapstructure:"recvIdList"`
 
 	// 接收者
-	RecvId string `mapstructure:"recvId"`
+	RecvId string `json:"recvId" mapstructure:"recvId"`
 
 	// 发送时间
-	SendTime int64 `mapstructure:"sendTime"`
+	SendTime int64 `json:"sendTime" mapstructure:"sendTime"`
 
 	// 已读记录 key为消息id、value为消息值
-	ReadRecords map[string]string `mapstructure:"readRecords"`
+	ReadRecords map[string]string `json:"readRecords" mapstructure:"readRecords"`
 
-	constants.MType `mapstructure:"mType"`
-	Content         string `mapstructure:"content"`
+	constants.MType `json:"mType" mapstructure:"mType"`
+	Content         string `json:"content" mapstructure:"content"`
 }
 
 // MarkRead 已读标记
 type MarkRead struct {
-	constants.ChatType `mapstructure:"chatType"`
-	RecvId             string `mapstructure:"recvId"`
-	ConversationId     string `mapstructure:"conversationId"`
+	constants.ChatType `json:"chatType" mapstructure:"chatType"`
+	RecvId             string `json:"recvId" mapstructure:"recvId"`
+	ConversationId     string `json:"conversationId" mapstructure:"conversationId"`
 	// 发送者
-	SendId      string            `mapstructure:"sendId"`
-	MsgIds      []string          `mapstructure:"msgIds"`
-	ReadRecords map[string]string `mapstructure:"readRecords"`
+	SendId      string            `json:"sendId" mapstructure:"sendId"`
+	MsgIds      []string          `json:"msgIds" mapstructure:"msgIds"`
+	ReadRecords map[string]string `json:"readRecords" mapstructure:"readRecords"`
 }

--- a/im_web/src/app/page.tsx
+++ b/im_web/src/app/page.tsx
@@ -2,18 +2,57 @@
 
 import { useState, useEffect } from 'react';
 import { useIMStore } from '@/lib/im-store';
+import { useChatStore } from '@/lib/chat-store';
 import IMLayout from '@/components/im/IMLayout';
 import AuthPage from '@/components/auth/AuthPage';
 import SettingsProvider from '@/components/SettingsProvider';
 
+async function fetchFriendsForStore(token: string) {
+  try {
+    const resp = await fetch('/api/social/friends', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const json = await resp.json();
+    const list = json?.list || json?.data?.list || [];
+    const mapped = list.map((f: any) => ({
+      id: String(f.id || f.friend_uid || ''),
+      friend_uid: String(f.friend_uid || ''),
+      name: f.nickname || f.remark || String(f.friend_uid || ''),
+      remark: f.remark || '',
+      avatar: f.avatar || '',
+      pinyin: '', letter: '',
+    }));
+    useIMStore.getState().setFriends(mapped);
+  } catch { /* ignore */ }
+}
+
 export default function Home() {
-  const { isAuthenticated } = useIMStore();
+  const { isAuthenticated, currentUser } = useIMStore();
+  const initWs = useChatStore(s => s.initWs);
+  const destroyWs = useChatStore(s => s.destroyWs);
+  const fetchConversations = useChatStore(s => s.fetchConversations);
   const [hydrated, setHydrated] = useState(false);
+
+  const fetchFriendsAndConversations = async (token: string) => {
+    await fetchFriendsForStore(token);
+    await fetchConversations(token);
+  };
 
   // Wait for zustand persist to rehydrate from localStorage before rendering
   useEffect(() => {
     setHydrated(true);
   }, []);
+
+  // 登录后立即初始化 WebSocket + 拉取好友列表和会话列表
+  useEffect(() => {
+    if (isAuthenticated && currentUser?.token && currentUser?.id) {
+      initWs(currentUser.token, currentUser.id);
+      // 先加载好友列表，再加载会话列表（会话名称依赖好友数据）
+      fetchFriendsAndConversations(currentUser.token);
+    }
+    return () => { destroyWs(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, currentUser?.token, currentUser?.id]);
 
   if (!hydrated) {
     return null;

--- a/im_web/src/components/im/CallDialog.tsx
+++ b/im_web/src/components/im/CallDialog.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { Phone, Video, Check, Users } from 'lucide-react';
 import { getAvatarColor } from '@/lib/utils';
 import type { GroupMember } from '@/lib/mock-data';
@@ -70,6 +71,7 @@ export function CallDialog({ open, onOpenChange, type, contactName, isGroup = fa
         showCloseButton={false}
         className="!border-none !bg-transparent !p-0 !shadow-none !gap-0 data-[state=open]:!animate-none data-[state=closed]:!animate-none"
       >
+        <VisuallyHidden><DialogTitle>通话</DialogTitle></VisuallyHidden>
         <div
           style={{
             display: 'flex',

--- a/im_web/src/components/im/ChatDetail.tsx
+++ b/im_web/src/components/im/ChatDetail.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { conversations, conversationMessagesMap, formatTime, currentUser, groupMemberNames, groupMembersMap, contacts, type Message, type Contact } from '@/lib/mock-data';
+import { formatTime, currentUser as mockCurrentUser, groupMemberNames, groupMembersMap, contacts, type Message, type Contact } from '@/lib/mock-data';
 import { useIMStore } from '@/lib/im-store';
+import { useChatStore } from '@/lib/chat-store';
 import { getAvatarColor } from '@/lib/utils';
 import { toast } from 'sonner';
 import {
@@ -38,6 +39,9 @@ export default function ChatDetail() {
   // Local mutable conversation overrides (muted, pinned)
   const [convOverrides, setConvOverrides] = useState<Record<string, { muted?: boolean; pinned?: boolean }>>({});
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [noMoreHistory, setNoMoreHistory] = useState(false);
   const isMobile = useIsMobile();
 
   // Context menu state
@@ -63,7 +67,15 @@ export default function ChatDetail() {
   // Recalled messages tracking
   const [recalledIds, setRecalledIds] = useState<Set<string>>(new Set());
 
-  const conversation = conversations.find(c => c.id === selectedConversationId);
+  // 优先使用 chat-store 真实数据，fallback 到 mock 数据
+  const chatConversations = useChatStore(s => s.conversations);
+  const chatMessages = useChatStore(s => s.messagesMap);
+  const fetchMessages = useChatStore(s => s.fetchMessages);
+  const storeSendMessage = useChatStore(s => s.sendMessage);
+  const clearUnread = useChatStore(s => s.clearUnread);
+  const { currentUser } = useIMStore();
+
+  const conversation = chatConversations.find(c => c.id === selectedConversationId);
 
   // Merged conversation data with local overrides
   const conv = useMemo(() => {
@@ -72,23 +84,77 @@ export default function ChatDetail() {
     return { ...conversation, ...override };
   }, [conversation, convOverrides]);
 
-  // Find the contact matching the conversation partner
+  // Find the contact matching the conversation partner (by ID, not by name)
+  const { friends } = useIMStore();
+  const userProfiles = useChatStore(s => s.userProfiles);
   const contactMatch = useMemo<Contact | null>(() => {
-    if (!conv || conv.type !== 'private') return null;
+    if (!conv || conv.type !== 'private' || !currentUser?.id) return null;
+    // 从 conversationId 提取对方 userId
+    const parts = conv.id.split('_');
+    const peerId = parts.find(p => p !== currentUser.id);
+    if (!peerId) return null;
+    // 优先从 friends 列表查找
+    const friend = friends.find(c => c.id === peerId || c.friend_uid === peerId);
+    if (friend) return friend;
+    // fallback: 从 userProfiles 构造最小 Contact
+    const profile = userProfiles[peerId];
+    if (profile) {
+      return { id: peerId, name: profile.nickname, avatar: profile.avatar, pinyin: '', letter: '' } as Contact;
+    }
+    // fallback: mock contacts (by name)
     return contacts.find(c => c.name === conv.name) || null;
-  }, [conv]);
+  }, [conv, currentUser?.id, friends, userProfiles]);
 
-  // Derive the current message list from the selected conversation + any sent messages
+  // 对方显示名称和头像（优先 contactMatch，fallback conv）
+  const peerName = contactMatch?.remark || contactMatch?.name || conv?.name || '';
+  const peerAvatar = contactMatch?.avatar || conv?.avatar || '';
+
+  // 加载聊天记录 & 清除未读
+  useEffect(() => {
+    if (selectedConversationId && currentUser?.token) {
+      setNoMoreHistory(false); // 切换会话时重置
+      fetchMessages(currentUser.token, selectedConversationId);
+      clearUnread(selectedConversationId);
+    }
+  }, [selectedConversationId, currentUser?.token]);
+
+  // Derive the current message list: chat-store 真实消息 + 本地 sentMap (兼容 mock)
   const messages = useMemo<Message[]>(() => {
     if (!selectedConversationId) return [];
-    const base = conversationMessagesMap[selectedConversationId] || [];
+    const storeMsgs = chatMessages[selectedConversationId] || [];
     const extra = sentMap[selectedConversationId] || [];
-    return [...base, ...extra];
-  }, [selectedConversationId, sentMap]);
+    return [...storeMsgs, ...extra];
+  }, [selectedConversationId, chatMessages, sentMap]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  // 滚动到顶部时加载更早的聊天记录
+  const handleMessagesScroll = useCallback(() => {
+    const el = messagesContainerRef.current;
+    if (!el || loadingMore || noMoreHistory) return;
+    if (el.scrollTop < 50) {
+      const msgs = chatMessages[selectedConversationId!] || [];
+      if (msgs.length === 0) return;
+      const oldestId = msgs[0]?.id;
+      if (!oldestId || oldestId.startsWith('local_')) return;
+      setLoadingMore(true);
+      const prevCount = msgs.length;
+      const prevHeight = el.scrollHeight;
+      fetchMessages(currentUser!.token, selectedConversationId!, oldestId).then(() => {
+        requestAnimationFrame(() => {
+          const newMsgs = useChatStore.getState().messagesMap[selectedConversationId!] || [];
+          // 没有加载到新消息 → 已到头
+          if (newMsgs.length <= prevCount) {
+            setNoMoreHistory(true);
+          }
+          el.scrollTop = el.scrollHeight - prevHeight;
+          setLoadingMore(false);
+        });
+      }).catch(() => setLoadingMore(false));
+    }
+  }, [selectedConversationId, loadingMore, noMoreHistory, chatMessages, currentUser, fetchMessages]);
 
   const handleBack = () => {
     if (isMobile) {
@@ -100,18 +166,26 @@ export default function ChatDetail() {
 
   const handleSend = () => {
     if (!input.trim() || !selectedConversationId) return;
-    const newMsg: Message = {
-      id: `msg-${Date.now()}`,
-      senderId: 'me',
-      content: input.trim(),
-      timestamp: new Date(),
-      type: 'text',
-      replyTo: replyTo ? { senderName: replyTo.senderName, content: replyTo.message.content } : undefined,
-    };
-    setSentMap(prev => ({
-      ...prev,
-      [selectedConversationId]: [...(prev[selectedConversationId] || []), newMsg],
-    }));
+
+    // 通过 chat-store 发送（走 WebSocket RigorAck）
+    if (currentUser?.token && currentUser?.id) {
+      storeSendMessage(currentUser.token, currentUser.id, selectedConversationId, input.trim());
+    } else {
+      // Fallback: 本地 mock 发送
+      const newMsg: Message = {
+        id: `msg-${Date.now()}`,
+        senderId: 'me',
+        content: input.trim(),
+        timestamp: new Date(),
+        type: 'text',
+        replyTo: replyTo ? { senderName: replyTo.senderName, content: replyTo.message.content } : undefined,
+      };
+      setSentMap(prev => ({
+        ...prev,
+        [selectedConversationId]: [...(prev[selectedConversationId] || []), newMsg],
+      }));
+    }
+
     setInput('');
     setReplyTo(null);
   };
@@ -279,17 +353,18 @@ export default function ChatDetail() {
             } : undefined}
             style={{
               width: 40, height: 40, borderRadius: '50%', flexShrink: 0,
-              background: getAvatarColor(conv.name),
+              background: peerAvatar ? 'transparent' : getAvatarColor(peerName),
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               color: '#FFFFFF', fontSize: 16, fontWeight: 600,
               cursor: contactMatch ? 'pointer' : 'default',
+              overflow: 'hidden',
             }}
           >
-            {conv.name[0]}
+            {peerAvatar ? <img src={peerAvatar} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} /> : peerName[0]}
           </div>
           <div className="min-w-0">
             <h2 className="truncate" style={{ fontSize: 15, fontWeight: 600, color: '#1C2733', lineHeight: 1.3 }}>
-              {conv.name}
+              {peerName}
             </h2>
             {conv.type === 'group' ? (
               <p className="truncate" style={{ fontSize: 12, color: '#708499', lineHeight: 1.3, marginTop: 1 }}>
@@ -365,6 +440,8 @@ export default function ChatDetail() {
 
       {/* ── Messages Area: light gray background ── */}
       <div
+        ref={messagesContainerRef}
+        onScroll={handleMessagesScroll}
         className="flex-1 overflow-y-auto im-scroll"
         style={{
           padding: '8px 0',
@@ -372,6 +449,16 @@ export default function ChatDetail() {
         }}
       >
         <div style={{ display: 'flex', flexDirection: 'column', padding: '0 2%', minHeight: '100%' }}>
+          {loadingMore && (
+            <div style={{ textAlign: 'center', padding: '8px 0', color: '#A2ACB5', fontSize: 12 }}>
+              加载中...
+            </div>
+          )}
+          {noMoreHistory && !loadingMore && (
+            <div style={{ textAlign: 'center', padding: '8px 0', color: '#A2ACB5', fontSize: 12 }}>
+              没有更多消息了
+            </div>
+          )}
           <MessageList
             messages={displayMessages}
             conversation={conv}
@@ -492,7 +579,7 @@ export default function ChatDetail() {
           open={callDialogOpen}
           onOpenChange={setCallDialogOpen}
           type={callType}
-          contactName={conv.name}
+          contactName={peerName}
           isGroup={conv.type === 'group'}
           members={conv.type === 'group' ? (groupMembersMap[conv.id] || []) : []}
         />
@@ -531,14 +618,9 @@ export default function ChatDetail() {
           message={forwardMsg}
           onClose={() => setForwardMsg(null)}
           onForward={(targetConvId) => {
-            setSentMap(prev => ({
-              ...prev,
-              [targetConvId]: [...(prev[targetConvId] || []), {
-                ...forwardMsg,
-                id: `fwd-${Date.now()}`,
-                timestamp: new Date(),
-              }],
-            }));
+            if (currentUser?.token && currentUser?.id) {
+              storeSendMessage(currentUser.token, currentUser.id, targetConvId, forwardMsg.content, forwardMsg.type);
+            }
             setForwardMsg(null);
             toast.success('转发成功');
           }}
@@ -563,6 +645,8 @@ function MessageList({
   recalledIds: Set<string>;
   onBubbleContext: (e: React.MouseEvent | React.TouchEvent, message: Message, senderName: string, isOwn: boolean) => void;
 }) {
+  const { currentUser } = useIMStore();
+  const { selectedConversationId } = useIMStore();
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isLongPressRef = useRef(false);
 
@@ -628,12 +712,17 @@ function MessageList({
     }
   }, []);
 
+  // 判断消息是否是自己发的 (兼容 mock 的 'me' 和真实 userId)
+  const isOwnMessage = useCallback((senderId: string) => {
+    return senderId === 'me' || senderId === currentUser?.id;
+  }, [currentUser?.id]);
+
   // Get sender name for a message
   const getSenderName = useCallback((senderId: string) => {
-    if (senderId === 'me') return currentUser.name;
-    if (conversation.type === 'group') return groupMemberNames[senderId] || senderId;
-    return conversation.name;
-  }, [conversation]);
+    if (isOwnMessage(senderId)) return currentUser?.name || mockCurrentUser.name;
+    if (conversation?.type === 'group') return groupMemberNames[senderId] || senderId;
+    return conversation?.name || senderId;
+  }, [conversation, currentUser?.name, isOwnMessage]);
 
   return (
     <>
@@ -657,7 +746,7 @@ function MessageList({
 
         const { msgs } = group;
         const lastMsg = msgs[msgs.length - 1];
-        const isSent = msgs[0].senderId === 'me';
+        const isSent = isOwnMessage(msgs[0].senderId);
 
         return (
           <div key={group.key} style={{
@@ -698,7 +787,7 @@ function MessageList({
                 </span>
               )}
               {msgs.map((m) => {
-                const msgIsSent = m.senderId === 'me';
+                const msgIsSent = isOwnMessage(m.senderId);
                 const senderName = getSenderName(m.senderId);
 
                 return (
@@ -713,7 +802,7 @@ function MessageList({
                   >
                     {recalledIds.has(m.id) ? (
                       <span style={{ fontStyle: 'italic', opacity: 0.6 }}>
-                        {m.senderId === 'me' ? '你撤回了一条消息' : '对方撤回了一条消息'}
+                        {isOwnMessage(m.senderId) ? '你撤回了一条消息' : '对方撤回了一条消息'}
                       </span>
                     ) : (
                       <>
@@ -743,7 +832,7 @@ function MessageList({
                 );
               })}
 
-              {/* Timestamp */}
+              {/* Timestamp + Status */}
               <div style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -751,9 +840,25 @@ function MessageList({
                 marginTop: 4,
                 flexDirection: isSent ? 'row-reverse' : 'row',
               }}>
-                {isSent && <CheckCheck style={{ width: 14, height: 14, color: 'rgba(51,144,236,0.5)' }} />}
-                <span style={{ fontSize: 11, color: '#A2ACB5', lineHeight: 1 }}>
-                  {formatTime(lastMsg.timestamp)}
+                {isSent && lastMsg.status === 'failed' && (
+                  <span
+                    title="发送失败，点击重试"
+                    onClick={() => {
+                      if (currentUser?.token && currentUser?.id && selectedConversationId) {
+                        useChatStore.getState().resendMessage(currentUser.token, currentUser.id, selectedConversationId, lastMsg.id);
+                      }
+                    }}
+                    style={{ cursor: 'pointer', color: '#e74c3c', fontSize: 14, lineHeight: 1 }}
+                  >!</span>
+                )}
+                {isSent && lastMsg.status === 'sending' && (
+                  <span style={{ fontSize: 11, color: '#A2ACB5' }}>...</span>
+                )}
+                {isSent && lastMsg.status !== 'failed' && lastMsg.status !== 'sending' && (
+                  <CheckCheck style={{ width: 14, height: 14, color: 'rgba(51,144,236,0.5)' }} />
+                )}
+                <span style={{ fontSize: 11, color: lastMsg.status === 'failed' ? '#e74c3c' : '#A2ACB5', lineHeight: 1 }}>
+                  {lastMsg.status === 'failed' ? '发送失败' : formatTime(lastMsg.timestamp)}
                 </span>
               </div>
             </div>
@@ -763,11 +868,11 @@ function MessageList({
               <div style={{ width: 36, flexShrink: 0, marginLeft: 8 }}>
                 <div style={{
                   width: 36, height: 36, borderRadius: '50%',
-                  background: getAvatarColor(currentUser.name),
+                  background: getAvatarColor(currentUser?.name || mockCurrentUser.name),
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                   color: '#FFFFFF', fontSize: 13, fontWeight: 600,
                 }}>
-                  {currentUser.name[0]}
+                  {(currentUser?.name || mockCurrentUser.name)[0]}
                 </div>
               </div>
             )}

--- a/im_web/src/components/im/ChatList.tsx
+++ b/im_web/src/components/im/ChatList.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { useState, useMemo, useCallback, createContext, useContext } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, createContext, useContext } from 'react';
 import {
-  conversations,
   contacts,
   conversationMessagesMap,
   formatTime,
@@ -11,6 +10,7 @@ import {
   type Message,
 } from '@/lib/mock-data';
 import { useIMStore } from '@/lib/im-store';
+import { useChatStore } from '@/lib/chat-store';
 import { useIsMobile } from '@/hooks/use-mobile';
 import {
   Search,
@@ -68,8 +68,16 @@ export function ChatListProvider({ children }: { children: React.ReactNode }) {
   const [localSearch, setLocalSearch] = useState('');
   const [editMode, setEditMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [localConversations, setLocalConversations] = useState<Conversation[]>(conversations);
+  const chatStoreConvs = useChatStore(s => s.conversations);
+  const [localConversations, setLocalConversations] = useState<Conversation[]>(chatStoreConvs);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+
+  // 当 chat-store 数据更新时同步到 localConversations
+  useEffect(() => {
+    if (chatStoreConvs.length > 0) {
+      setLocalConversations(chatStoreConvs);
+    }
+  }, [chatStoreConvs]);
 
   return (
     <ChatListContext.Provider value={{
@@ -215,6 +223,9 @@ function ConversationItem({
   editMode,
   editSelected,
   onToggleSelect,
+  onDelete,
+  onTogglePin,
+  onToggleMute,
 }: {
   conversation: Conversation;
   isActive: boolean;
@@ -223,18 +234,68 @@ function ConversationItem({
   editMode?: boolean;
   editSelected?: boolean;
   onToggleSelect?: () => void;
+  onDelete?: () => void;
+  onTogglePin?: () => void;
+  onToggleMute?: () => void;
 }) {
   const avatarSize = 48;
   const showCheckbox = editMode;
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+
+  // 关闭右键菜单
+  useEffect(() => {
+    if (!ctxMenu) return;
+    const close = () => setCtxMenu(null);
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, [ctxMenu]);
 
   return (
     <div
       className={`im-conversation-item ${isActive ? 'active' : ''}`}
       onClick={editMode ? onToggleSelect : onClick}
+      onContextMenu={(e) => {
+        if (editMode) return;
+        e.preventDefault();
+        setCtxMenu({ x: e.clientX, y: e.clientY });
+      }}
       style={{
         transition: 'background-color 0.15s',
+        position: 'relative',
       }}
     >
+      {/* 右键菜单 */}
+      {ctxMenu && (
+        <div
+          style={{
+            position: 'fixed', left: ctxMenu.x, top: ctxMenu.y, zIndex: 9999,
+            background: '#2C3E50', borderRadius: 10, padding: '4px 0',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.4)', minWidth: 140,
+            border: '1px solid rgba(255,255,255,0.1)',
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {[
+            { label: conversation.pinned ? '取消置顶' : '置顶', action: onTogglePin },
+            { label: conversation.muted ? '取消免打扰' : '免打扰', action: onToggleMute },
+            { label: '删除会话', action: onDelete, danger: true },
+          ].map(({ label, action, danger }) => (
+            <button
+              key={label}
+              onClick={() => { setCtxMenu(null); action?.(); }}
+              style={{
+                display: 'block', width: '100%', padding: '8px 16px', border: 'none',
+                background: 'transparent', color: danger ? '#E53935' : '#FFFFFF',
+                fontSize: 13, textAlign: 'left', cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => { (e.target as HTMLElement).style.background = 'rgba(255,255,255,0.08)'; }}
+              onMouseLeave={(e) => { (e.target as HTMLElement).style.background = 'transparent'; }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
       {/* Checkbox (edit mode) */}
       {showCheckbox && (
         <div
@@ -259,14 +320,14 @@ function ConversationItem({
         </div>
       )}
 
-      {/* Avatar — colored circle with white initial */}
+      {/* Avatar */}
       <div className="relative shrink-0">
         <div
           style={{
             width: avatarSize,
             height: avatarSize,
             borderRadius: '50%',
-            background: isActive && !editMode ? 'rgba(255,255,255,0.2)' : getAvatarColor(conversation.name),
+            background: conversation.avatar ? 'transparent' : (isActive && !editMode ? 'rgba(255,255,255,0.2)' : getAvatarColor(conversation.name)),
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -277,7 +338,9 @@ function ConversationItem({
             overflow: 'hidden',
           }}
         >
-          {conversation.name[0]}
+          {conversation.avatar
+            ? <img src={conversation.avatar} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            : (conversation.name?.[0] || '?')}
         </div>
         {/* Online indicator */}
         {conversation.online && conversation.type === 'private' && (
@@ -417,7 +480,7 @@ function SearchConversationItem({
             width: 44,
             height: 44,
             borderRadius: '50%',
-            background: getAvatarColor(conv.name),
+            background: conv.avatar ? 'transparent' : getAvatarColor(conv.name),
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -428,7 +491,9 @@ function SearchConversationItem({
             overflow: 'hidden',
           }}
         >
-          {conv.name[0]}
+          {conv.avatar
+            ? <img src={conv.avatar} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            : (conv.name?.[0] || '?')}
         </div>
       </div>
       <div className="flex-1 min-w-0">
@@ -944,6 +1009,10 @@ export function ChatListContent() {
   }, [setDeleteConfirm]);
 
   const confirmDelete = useCallback(() => {
+    const token = useIMStore.getState().currentUser?.token;
+    if (token) {
+      selectedIds.forEach(id => useChatStore.getState().deleteConversation(token, id));
+    }
     setLocalConversations((prev) => prev.filter((c) => !selectedIds.has(c.id)));
     setSelectedIds(new Set());
     setDeleteConfirm(false);
@@ -967,8 +1036,9 @@ export function ChatListContent() {
   // ── Handle clicking a contact → open their conversation ──
   const handleContactClick = useCallback(
     (contact: Contact) => {
+      // 按 id 匹配 (conversationId 包含对方 userId)
       const conv = localConversations.find(
-        (c) => c.type === 'private' && c.name === contact.name
+        (c) => c.type === 'private' && c.id.split('_').includes(contact.id)
       );
       if (conv) {
         setSelectedConversationId(conv.id);
@@ -1057,6 +1127,23 @@ export function ChatListContent() {
                 editMode={isBatchMode}
                 editSelected={selectedIds.has(conv.id)}
                 onToggleSelect={() => toggleSelect(conv.id)}
+                onDelete={() => {
+                  const token = useIMStore.getState().currentUser?.token;
+                  if (token) useChatStore.getState().deleteConversation(token, conv.id);
+                  setLocalConversations(prev => prev.filter(c => c.id !== conv.id));
+                  if (selectedConversationId === conv.id) setSelectedConversationId(null);
+                  toast.success('会话已删除');
+                }}
+                onTogglePin={() => {
+                  setLocalConversations(prev => prev.map(c =>
+                    c.id === conv.id ? { ...c, pinned: !c.pinned } : c
+                  ));
+                }}
+                onToggleMute={() => {
+                  setLocalConversations(prev => prev.map(c =>
+                    c.id === conv.id ? { ...c, muted: !c.muted } : c
+                  ));
+                }}
               />
             ))}
 

--- a/im_web/src/components/im/ContactDetailPanel.tsx
+++ b/im_web/src/components/im/ContactDetailPanel.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useCallback } from 'react';
 import { type Contact } from '@/lib/mock-data';
 import { useIMStore } from '@/lib/im-store';
+import { useChatStore } from '@/lib/chat-store';
 import { toast } from 'sonner';
 import UserProfileCard from './UserProfileCard';
 import { ArrowLeft } from 'lucide-react';
@@ -28,9 +29,19 @@ export default function ContactDetailPanel({ contact }: ContactDetailPanelProps)
     return () => window.removeEventListener('keydown', handleKey);
   }, [handleClose]);
 
-  const handleSendMessage = () => {
-    // TODO: integrate with real conversation lookup
-    toast.info(`暂无与 ${contact.name} 的会话`);
+  const handleSendMessage = async () => {
+    if (!currentUser?.token || !currentUser?.id) return;
+    try {
+      const conv = await useChatStore.getState().getOrCreateConversation(
+        currentUser.token, currentUser.id, contact.id
+      );
+      setSelectedContactId(null);
+      setActiveTab('chats');
+      setSelectedConversationId(conv.id);
+      setShowChatDetail(true);
+    } catch {
+      toast.error('打开会话失败');
+    }
   };
 
   const handleVoiceCall = () => {

--- a/im_web/src/components/im/ForwardDialog.tsx
+++ b/im_web/src/components/im/ForwardDialog.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { X } from 'lucide-react';
-import { conversations, type Message } from '@/lib/mock-data';
+import { type Message } from '@/lib/mock-data';
+import { useChatStore } from '@/lib/chat-store';
 import { getAvatarColor } from '@/lib/utils';
 
 interface ForwardDialogProps {
@@ -12,6 +13,8 @@ interface ForwardDialogProps {
 }
 
 export default function ForwardDialog({ message, onClose, onForward }: ForwardDialogProps) {
+  const conversations = useChatStore(s => s.conversations);
+
   return (
     <div
       style={{

--- a/im_web/src/components/im/GroupList.tsx
+++ b/im_web/src/components/im/GroupList.tsx
@@ -37,6 +37,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useIMStore } from '@/lib/im-store';
+import { useChatStore } from '@/lib/chat-store';
 import { getAvatarColor } from '@/lib/utils';
 import {
   type GroupInfo,
@@ -310,7 +311,7 @@ type DetailTab = 'members' | 'links' | 'announcements';
 type AppStatusFilter = 'all' | GroupAppResult;
 
 export default function GroupList() {
-  const { setShowGroupPanel, groupAppUnreadCount, setGroupAppUnreadCount, currentUser, friends } = useIMStore();
+  const { setShowGroupPanel, groupAppUnreadCount, setGroupAppUnreadCount, currentUser, friends, setActiveTab, setSelectedConversationId, setShowChatDetail } = useIMStore();
   const token = currentUser?.token || '';
   const myUserId = currentUser?.id || '';
 
@@ -806,8 +807,15 @@ export default function GroupList() {
     }
   }, [selectedGroupId, editName, editDesc, editIcon, editIconFile, editVerify, token]);
 
-  // Send message
-  const handleSendMessage = useCallback(() => { toast.success('正在打开聊天...'); }, []);
+  // Send message to group
+  const handleSendMessage = useCallback(() => {
+    if (!selectedGroup) return;
+    // 群聊 conversationId 就是 groupId
+    setShowGroupPanel(false);
+    setActiveTab('chats');
+    setSelectedConversationId(selectedGroup.id);
+    setShowChatDetail(true);
+  }, [selectedGroup, setShowGroupPanel, setActiveTab, setSelectedConversationId, setShowChatDetail]);
 
   // Invite friends
   const handleInviteFriends = useCallback(async () => {
@@ -1894,7 +1902,18 @@ export default function GroupList() {
                 {/* 底部操作按钮 */}
                 <div className="flex items-center gap-2">
                   {isFriend ? (
-                    <button onClick={() => { setProfileTarget(null); toast.info('请到聊天列表发消息'); }} style={{ flex: 1, padding: '10px', borderRadius: '10px', border: 'none', background: '#3390EC', color: '#FFF', fontSize: '14px', fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+                    <button onClick={async () => {
+                      const memberId = profileTarget?.userId || profileTarget?.id;
+                      setProfileTarget(null);
+                      if (!currentUser?.token || !currentUser?.id || !memberId) return;
+                      try {
+                        const conv = await useChatStore.getState().getOrCreateConversation(currentUser.token, currentUser.id, memberId);
+                        setShowGroupPanel(false);
+                        setActiveTab('chats');
+                        setSelectedConversationId(conv.id);
+                        setShowChatDetail(true);
+                      } catch { toast.error('打开会话失败'); }
+                    }} style={{ flex: 1, padding: '10px', borderRadius: '10px', border: 'none', background: '#3390EC', color: '#FFF', fontSize: '14px', fontWeight: 500, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
                       <Send className="w-4 h-4" /> 发消息
                     </button>
                   ) : !alreadySent ? (

--- a/im_web/src/components/im/IMLayout.tsx
+++ b/im_web/src/components/im/IMLayout.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { useIMStore, TabType } from '@/lib/im-store';
-import { conversations, type Contact } from '@/lib/mock-data';
+import { type Contact } from '@/lib/mock-data';
+import { useChatStore } from '@/lib/chat-store';
 import { ChatListProvider, ChatListToolbar, ChatListContent } from './ChatList';
 import ChatDetail from './ChatDetail';
 import ContactList from './ContactList';
@@ -35,12 +36,9 @@ const navItems: { tab: TabType; icon: React.ReactNode }[] = [
   { tab: 'me', icon: <User className="w-5 h-5" /> },
 ];
 
-function getTotalUnread(): number {
-  return conversations.reduce((sum, c) => sum + c.unreadCount, 0);
-}
-
 export default function IMLayout() {
   const { activeTab, setActiveTab, showChatDetail, selectedContactId, showFriendRequests, showGroupPanel, selectedTrendId, meSubPage, setMeSubPage, currentUser, friends } = useIMStore();
+  const chatConversations = useChatStore(s => s.conversations);
 
   // Resolve selected contact for detail panel from store friends
   const selectedContact: Contact | null = React.useMemo(() => {
@@ -48,7 +46,7 @@ export default function IMLayout() {
     return friends.find(c => c.id === selectedContactId) || null;
   }, [selectedContactId, friends]);
   const isMobile = useIsMobile();
-  const totalUnread = getTotalUnread();
+  const totalUnread = chatConversations.reduce((sum, c) => sum + c.unreadCount, 0);
   const t = useT();
 
   const tabLabels: Record<TabType, string> = {

--- a/im_web/src/lib/api-client.ts
+++ b/im_web/src/lib/api-client.ts
@@ -3,6 +3,7 @@
 const BACKEND_BASE = process.env.BACKEND_API_URL || 'http://127.0.0.1:8887';
 const SOCIAL_BASE = process.env.SOCIAL_API_URL || 'http://127.0.0.1:8888';
 const TREND_BASE = process.env.TREND_API_URL || 'http://127.0.0.1:8891';
+const IM_BASE = process.env.IM_API_URL || 'http://127.0.0.1:8890';
 
 export interface BackendResp<T = unknown> {
   code: number;
@@ -137,4 +138,92 @@ export async function trendGet<T = unknown>(
     },
   });
   return res.json() as Promise<BackendResp<T>>;
+}
+
+// ========== IM service clients (port 8890) ==========
+
+// IM API 直接返回数据对象（不是 {code, data} 包装），用独立的 fetch 函数
+async function imFetch<T = unknown>(path: string, options: RequestInit = {}): Promise<T> {
+  const url = `${IM_BASE}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+  if (!res.ok) throw new Error(`IM API error: ${res.status} ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+export function imGet<T = unknown>(path: string, token?: string): Promise<T> {
+  return imFetch<T>(path, {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+export function imPost<T = unknown>(path: string, body: unknown, token?: string): Promise<T> {
+  return imFetch<T>(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+export function imPut<T = unknown>(path: string, body: unknown, token?: string): Promise<T> {
+  return imFetch<T>(path, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+// ========== IM typed API helpers ==========
+
+export interface ChatLogItem {
+  id: string;
+  conversationId: string;
+  sendId: string;
+  recvId: string;
+  msgType: number;
+  msgContent: string;
+  chatType: number;
+  sendTime: number;
+}
+
+export interface ConversationItem {
+  conversationId: string;
+  chatType: number;
+  isShow: boolean;
+  seq: number;
+  read: number;
+  message?: ChatLogItem;
+}
+
+/** 获取聊天记录 — 返回 {list: ChatLogItem[]} */
+export function getChatLog(token: string, conversationId: string, msgId = '', count = 30) {
+  const params = new URLSearchParams({ conversationId, count: String(count) });
+  if (msgId) params.set('msgId', msgId);
+  return imGet<{ list: ChatLogItem[] }>(`/v1/im/chatlog?${params}`, token);
+}
+
+/** 获取消息已读记录 */
+export function getChatLogReadRecords(token: string, msgId: string) {
+  return imGet<{ reads: string[]; unReads: string[] }>(`/v1/im/chatlog/readRecords?msgId=${msgId}`, token);
+}
+
+/** 获取会话列表 — 返回 {conversationList: Record<string, ConversationItem>} */
+export function getConversations(token: string) {
+  return imGet<{ conversationList: Record<string, ConversationItem> }>('/v1/im/conversation', token);
+}
+
+/** 建立会话 */
+export function setupConversation(token: string, sendId: string, recvId: string, chatType: number) {
+  return imPost('/v1/im/setup/conversation', { sendId, recvId, chatType }, token);
+}
+
+/** 更新会话 */
+export function updateConversations(token: string, conversationList: Record<string, Partial<ConversationItem>>) {
+  return imPut('/v1/im/conversation', { conversationList }, token);
 }

--- a/im_web/src/lib/chat-store.ts
+++ b/im_web/src/lib/chat-store.ts
@@ -1,0 +1,525 @@
+/**
+ * Chat Store — 管理会话列表、消息、WebSocket 生命周期
+ *
+ * 替代 mock-data 中的 conversations / conversationMessagesMap，
+ * 通过 IM REST API 获取数据 + WebSocket 实时推送。
+ */
+
+import { create } from 'zustand';
+import {
+  createIMWs,
+  getIMWs,
+  ChatType,
+  MsgType,
+  type WsChatData,
+} from './ws-client';
+import {
+  getChatLog,
+  getConversations,
+  setupConversation,
+  updateConversations,
+  type ChatLogItem,
+  type ConversationItem,
+  type BackendUser,
+} from './api-client';
+import { useIMStore } from './im-store';
+import type { Message, Conversation } from './mock-data';
+
+// ========== 消息类型映射 ==========
+
+const backMsgTypeMap: Record<number, Message['type']> = {
+  [MsgType.Text]: 'text',
+  [MsgType.File]: 'text',     // 暂时作为 text 展示
+  [MsgType.Voice]: 'voice',
+  [MsgType.Image]: 'image',
+  [MsgType.Memes]: 'text',
+};
+
+const frontMsgTypeMap: Record<string, number> = {
+  text: MsgType.Text,
+  image: MsgType.Image,
+  voice: MsgType.Voice,
+};
+
+// ========== Store 接口 ==========
+
+/** 用户资料缓存 */
+interface UserProfile {
+  id: string;
+  nickname: string;
+  avatar: string;
+}
+
+interface ChatState {
+  // 连接状态
+  wsState: 'disconnected' | 'connecting' | 'connected';
+
+  // 会话列表 (从 API 获取 + 实时更新)
+  conversations: Conversation[];
+
+  // 消息 (按 conversationId 分组)
+  messagesMap: Record<string, Message[]>;
+
+  // 用户资料缓存 (userId → profile)
+  userProfiles: Record<string, UserProfile>;
+
+  // 加载状态
+  loadingConversations: boolean;
+  loadingMessages: Record<string, boolean>;
+
+  // Actions
+  initWs: (token: string, userId: string, wsUrl?: string) => void;
+  destroyWs: () => void;
+  fetchConversations: (token: string) => Promise<void>;
+  fetchMessages: (token: string, conversationId: string, oldestMsgId?: string) => Promise<void>;
+  sendMessage: (token: string, userId: string, conversationId: string, content: string, msgType?: string) => void;
+  resendMessage: (token: string, userId: string, conversationId: string, msgId: string) => void;
+  markRead: (userId: string, conversationId: string, msgIds: string[]) => void;
+  getOrCreateConversation: (token: string, userId: string, targetId: string) => Promise<Conversation>;
+  deleteConversation: (token: string, conversationId: string) => void;
+  clearUnread: (conversationId: string) => void;
+}
+
+export const useChatStore = create<ChatState>()((set, get) => ({
+  wsState: 'disconnected',
+  conversations: [],
+  messagesMap: {},
+  userProfiles: {},
+  loadingConversations: false,
+  loadingMessages: {},
+
+  // ==================== WebSocket 生命周期 ====================
+
+  initWs: (token, userId, wsUrl) => {
+    // 开发环境直连 WS 服务 (10090)，生产环境通过 Caddy/Nginx 代理
+    const host = typeof window !== 'undefined' ? window.location.hostname : '';
+    const isDev = host === 'localhost' || host === '127.0.0.1';
+    const defaultWsUrl = isDev
+      ? `ws://${host}:10090/ws`
+      : `${window?.location?.protocol === 'https:' ? 'wss' : 'ws'}://${window?.location?.host}/ws`;
+
+    const ws = createIMWs({
+      url: wsUrl || defaultWsUrl,
+      token,
+      onStateChange: (state) => set({ wsState: state }),
+      onError: (err) => console.error('[ChatStore] ws error:', err),
+    });
+
+    // 服务端推送消息 — push.go NewMessage 不设 method，所以 method 为 ""
+    ws.on('', (data, raw) => {
+      const chat = data as WsChatData | null;
+      if (!chat?.conversationId) return;
+      handlePush(chat, raw?.id, userId);
+    });
+
+    ws.on('chat.ping', () => { /* pong */ });
+
+    ws.connect();
+  },
+
+  destroyWs: () => {
+    getIMWs().disconnect();
+    set({ wsState: 'disconnected' });
+  },
+
+  // ==================== REST API ====================
+
+  fetchConversations: async (token) => {
+    set({ loadingConversations: true });
+    try {
+      const resp = await getConversations(token);
+      const map = resp?.conversationList || {};
+      const list: Conversation[] = Object.values(map).map(mapConversation);
+      set({ conversations: list });
+
+      // 填充私聊会话的名称和头像
+      const currentUserId = useIMStore.getState().currentUser?.id;
+      if (currentUserId) {
+        const friends = useIMStore.getState().friends;
+        const unresolvedPeerIds = new Set<string>();
+
+        // 第一轮：用 friends 列表直接填充
+        const updated = list.map(c => {
+          if (c.type !== 'private') return c;
+          const parts = c.id.split('_');
+          const peerId = parts.find(p => p !== currentUserId);
+          if (!peerId) return c;
+          const friend = friends.find(f => f.id === peerId || f.friend_uid === peerId);
+          if (friend) {
+            return { ...c, name: friend.remark || friend.name, avatar: friend.avatar || '' };
+          }
+          unresolvedPeerIds.add(peerId);
+          return c;
+        });
+        set({ conversations: updated });
+
+        // 第二轮：剩余没有好友关系的 ID，走 API 查询
+        if (unresolvedPeerIds.size > 0) {
+          await resolveUserProfiles(token, [...unresolvedPeerIds]);
+          set(s => ({
+            conversations: s.conversations.map(c => {
+              if (c.type !== 'private') return c;
+              const parts = c.id.split('_');
+              const peerId = parts.find(p => p !== currentUserId);
+              const profile = peerId ? s.userProfiles[peerId] : null;
+              if (!profile || c.name !== c.id) return c; // 已有名字则不覆盖
+              return { ...c, name: profile.nickname, avatar: profile.avatar };
+            }),
+          }));
+        }
+      }
+    } catch (e) {
+      console.error('[ChatStore] fetch conversations error:', e);
+    } finally {
+      set({ loadingConversations: false });
+    }
+  },
+
+  fetchMessages: async (token, conversationId, oldestMsgId) => {
+    set(s => ({ loadingMessages: { ...s.loadingMessages, [conversationId]: true } }));
+    try {
+      const resp = await getChatLog(token, conversationId, oldestMsgId || '', 30);
+      // API 返回倒序（最新在前），前端需要正序（最早在前）
+      const list = (resp?.list || []).map(mapChatLog).reverse();
+
+      set(s => {
+        const existing = s.messagesMap[conversationId] || [];
+        // 加载更早的历史：放在前面；首次加载：替换
+        const merged = oldestMsgId ? [...list, ...existing] : list;
+        return { messagesMap: { ...s.messagesMap, [conversationId]: merged } };
+      });
+    } catch (e) {
+      console.error('[ChatStore] fetch messages error:', e);
+    } finally {
+      set(s => ({ loadingMessages: { ...s.loadingMessages, [conversationId]: false } }));
+    }
+  },
+
+  // ==================== 发送消息 ====================
+
+  sendMessage: (token, userId, conversationId, content, msgType = 'text') => {
+    const conv = get().conversations.find(c => c.id === conversationId);
+    const chatType = conv?.type === 'group' ? ChatType.Group : ChatType.Single;
+
+    // 解析接收者 ID
+    let recvId = '';
+    if (chatType === ChatType.Single) {
+      const parts = conversationId.split('_');
+      recvId = parts.find(p => p !== userId) || parts[0] || '';
+    } else {
+      recvId = conversationId;
+    }
+
+    // 乐观更新 UI
+    const localMsgId = `local_${Date.now()}`;
+    const localMsg: Message = {
+      id: localMsgId,
+      senderId: userId,
+      content,
+      timestamp: new Date(),
+      type: (msgType as Message['type']) || 'text',
+      status: 'sending',
+    };
+
+    set(s => {
+      const msgs = [...(s.messagesMap[conversationId] || []), localMsg];
+      const convs = s.conversations.map(c =>
+        c.id === conversationId
+          ? { ...c, lastMessage: content, lastMessageTime: new Date() }
+          : c,
+      );
+      return { messagesMap: { ...s.messagesMap, [conversationId]: msgs }, conversations: convs };
+    });
+
+    // 通过 WebSocket 发送 (RigorAck)
+    const ws = getIMWs();
+    const wsData: WsChatData = {
+      conversationId,
+      chatType,
+      sendId: userId,
+      recvId,
+      sendTime: Date.now() * 1e6,
+      msg: {
+        mType: frontMsgTypeMap[msgType] || MsgType.Text,
+        content,
+        readRecords: {},
+      },
+    };
+
+    const updateMsgStatus = (status: Message['status']) => {
+      set(s => {
+        const msgs = (s.messagesMap[conversationId] || []).map(m =>
+          m.id === localMsgId ? { ...m, status } : m,
+        );
+        return { messagesMap: { ...s.messagesMap, [conversationId]: msgs } };
+      });
+    };
+
+    ws.send('chat.user', wsData)
+      .then(() => updateMsgStatus('sent'))
+      .catch(err => {
+        console.error('[ChatStore] send failed:', err);
+        updateMsgStatus('failed');
+      });
+  },
+
+  // ==================== 重发失败消息 ====================
+
+  resendMessage: (token, userId, conversationId, msgId) => {
+    const msgs = get().messagesMap[conversationId] || [];
+    const failedMsg = msgs.find(m => m.id === msgId && m.status === 'failed');
+    if (!failedMsg) return;
+    // 删除旧消息，重新发送
+    set(s => ({
+      messagesMap: {
+        ...s.messagesMap,
+        [conversationId]: (s.messagesMap[conversationId] || []).filter(m => m.id !== msgId),
+      },
+    }));
+    get().sendMessage(token, userId, conversationId, failedMsg.content, failedMsg.type);
+  },
+
+  // ==================== 标记已读 ====================
+
+  markRead: (userId, conversationId, msgIds) => {
+    if (!msgIds.length) return;
+    const conv = get().conversations.find(c => c.id === conversationId);
+    const chatType = conv?.type === 'group' ? ChatType.Group : ChatType.Single;
+    let recvId = '';
+    if (chatType === ChatType.Single) {
+      const parts = conversationId.split('_');
+      recvId = parts.find(p => p !== userId) || '';
+    } else {
+      recvId = conversationId;
+    }
+
+    const readRecords: Record<string, string> = {};
+    msgIds.forEach(id => { readRecords[id] = '1'; });
+
+    getIMWs().send('chat.markChat', {
+      chatType, recvId, conversationId, sendId: userId, msgIds, readRecords,
+    }).catch(err => console.error('[ChatStore] markRead failed:', err));
+  },
+
+  // ==================== 建立会话 ====================
+
+  getOrCreateConversation: async (token, userId, targetId) => {
+    // 生成会话 ID (与后端 wuid.CombineId 一致: 按数值从小到大排序)
+    // Go 端用 strconv.ParseUint(id, 0, 64) 做数值比较
+    const parseId = (s: string) => {
+      try { return BigInt(s); } catch { return BigInt(0); }
+    };
+    const ids = [userId, targetId].sort((a, b) => {
+      const na = parseId(a), nb = parseId(b);
+      return na < nb ? -1 : na > nb ? 1 : 0;
+    });
+    const convId = `${ids[0]}_${ids[1]}`;
+
+    const existing = get().conversations.find(c => c.id === convId);
+    if (existing) return existing;
+
+    try {
+      await setupConversation(token, userId, targetId, ChatType.Single);
+    } catch { /* 会话可能已存在 */ }
+
+    // 查询对方用户资料
+    if (!get().userProfiles[targetId]) {
+      await resolveUserProfiles(token, [targetId]);
+    }
+    const profile = get().userProfiles[targetId];
+
+    const newConv: Conversation = {
+      id: convId,
+      type: 'private',
+      name: profile?.nickname || targetId,
+      avatar: profile?.avatar || '',
+      lastMessage: '',
+      lastMessageTime: new Date(),
+      unreadCount: 0,
+      pinned: false,
+      muted: false,
+    };
+    set(s => ({ conversations: [newConv, ...s.conversations] }));
+    return newConv;
+  },
+
+  // ==================== 删除会话 ====================
+
+  deleteConversation: (token, conversationId) => {
+    // 先从 UI 移除（乐观更新）
+    set(s => ({
+      conversations: s.conversations.filter(c => c.id !== conversationId),
+      messagesMap: Object.fromEntries(
+        Object.entries(s.messagesMap).filter(([k]) => k !== conversationId)
+      ),
+    }));
+
+    // 调后端 PUT /v1/im/conversation 设置 isShow=false
+    const conv = get().conversations.find(c => c.id === conversationId);
+    updateConversations(token, {
+      [conversationId]: {
+        conversationId,
+        chatType: conv?.type === 'group' ? ChatType.Group : ChatType.Single,
+        isShow: false,
+      } as any,
+    }).catch(err => console.error('[ChatStore] deleteConversation failed:', err));
+  },
+
+  // ==================== 清除未读 ====================
+
+  clearUnread: (conversationId) => {
+    set(s => ({
+      conversations: s.conversations.map(c =>
+        c.id === conversationId ? { ...c, unreadCount: 0 } : c,
+      ),
+    }));
+  },
+}));
+
+// ========== 内部辅助函数 ==========
+
+/**
+ * 智能解析后端时间戳 — 自动判断纳秒/微秒/毫秒/秒
+ * 后端 conversation.go 用 UnixNano (纳秒)，但 MongoDB 存储后可能被截断为毫秒
+ */
+/** 计算未读数，防止后端 seq 数据异常（如存了时间戳）导致天文数字 */
+function calcUnread(seq: number | undefined, read: number | undefined): number {
+  const s = seq || 0;
+  const r = read || 0;
+  const diff = s - r;
+  // seq 应该是消息序列号（小数字），不是时间戳（大数字）
+  // 如果差值超过 10000，说明数据异常，返回 0
+  if (diff <= 0 || diff > 10000) return 0;
+  return diff;
+}
+
+function parseTimestamp(ts: number): Date {
+  if (!ts) return new Date();
+  if (ts > 1e18) return new Date(ts / 1e6);  // 纳秒 → 毫秒
+  if (ts > 1e15) return new Date(ts / 1e3);  // 微秒 → 毫秒
+  if (ts > 1e12) return new Date(ts);         // 毫秒
+  return new Date(ts * 1000);                 // 秒
+}
+
+function mapConversation(raw: ConversationItem): Conversation {
+  const msg = raw.message;
+  return {
+    id: raw.conversationId,
+    type: raw.chatType === ChatType.Group ? 'group' : 'private',
+    name: raw.conversationId,
+    avatar: '',
+    lastMessage: msg?.msgContent || '',
+    lastMessageTime: msg?.sendTime ? parseTimestamp(msg.sendTime) : new Date(),
+    unreadCount: calcUnread(raw.seq, raw.read),
+    pinned: false,
+    muted: false,
+  };
+}
+
+function mapChatLog(log: ChatLogItem): Message {
+  return {
+    id: log.id,
+    senderId: log.sendId,
+    content: log.msgContent,
+    timestamp: log.sendTime ? parseTimestamp(log.sendTime) : new Date(),
+    type: backMsgTypeMap[log.msgType] || 'text',
+  };
+}
+
+/**
+ * 批量查询用户资料并写入 userProfiles 缓存
+ */
+async function resolveUserProfiles(token: string, userIds: string[]) {
+  if (userIds.length === 0) return;
+  try {
+    const resp = await fetch(`/api/user/search?ids=${userIds.join(',')}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const json = await resp.json();
+    const users: BackendUser[] = json.data?.users || [];
+    const profiles: Record<string, UserProfile> = {};
+    for (const u of users) {
+      profiles[u.id] = {
+        id: u.id,
+        nickname: u.nickname || u.id,
+        avatar: u.avatar || '',
+      };
+    }
+    useChatStore.setState(s => ({
+      userProfiles: { ...s.userProfiles, ...profiles },
+    }));
+  } catch (e) {
+    console.error('[ChatStore] resolveUserProfiles error:', e);
+  }
+}
+
+/** 从缓存获取用户昵称，无则返回 userId */
+function getProfileName(userId: string): string {
+  return useChatStore.getState().userProfiles[userId]?.nickname || userId;
+}
+
+function getProfileAvatar(userId: string): string {
+  return useChatStore.getState().userProfiles[userId]?.avatar || '';
+}
+
+/** 处理服务端推送的消息 */
+function handlePush(chat: WsChatData, rawId: string | undefined, currentUserId: string) {
+  const convId = chat.conversationId;
+  const msg: Message = {
+    id: rawId || `push_${Date.now()}`,
+    senderId: chat.sendId,
+    content: chat.msg?.content || '',
+    timestamp: chat.sendTime ? parseTimestamp(chat.sendTime) : new Date(),
+    type: backMsgTypeMap[chat.msg?.mType] || 'text',
+  };
+
+  useChatStore.setState(s => {
+    // 添加消息
+    const msgs = [...(s.messagesMap[convId] || []), msg];
+
+    // 更新或创建会话
+    let convs = [...s.conversations];
+    const idx = convs.findIndex(c => c.id === convId);
+    if (idx >= 0) {
+      convs[idx] = {
+        ...convs[idx],
+        lastMessage: msg.content,
+        lastMessageTime: msg.timestamp,
+        unreadCount: convs[idx].unreadCount + (chat.sendId !== currentUserId ? 1 : 0),
+      };
+    } else {
+      // 新会话 — 尝试用缓存的用户资料命名
+      const peerId = chat.sendId !== currentUserId ? chat.sendId : '';
+      convs = [{
+        id: convId,
+        type: chat.chatType === ChatType.Group ? 'group' : 'private',
+        name: peerId ? getProfileName(peerId) : convId,
+        avatar: peerId ? getProfileAvatar(peerId) : '',
+        lastMessage: msg.content,
+        lastMessageTime: msg.timestamp,
+        unreadCount: chat.sendId !== currentUserId ? 1 : 0,
+        pinned: false,
+        muted: false,
+      }, ...convs];
+    }
+
+    return { messagesMap: { ...s.messagesMap, [convId]: msgs }, conversations: convs };
+  });
+
+  // 如果发送者的资料不在缓存中，异步加载并回填
+  if (!useChatStore.getState().userProfiles[chat.sendId]) {
+    const token = useIMStore.getState().currentUser?.token;
+    if (token) {
+      resolveUserProfiles(token, [chat.sendId]).then(() => {
+        useChatStore.setState(s => ({
+          conversations: s.conversations.map(c => {
+            if (c.id !== convId || c.type !== 'private') return c;
+            const profile = s.userProfiles[chat.sendId];
+            if (!profile) return c;
+            return { ...c, name: profile.nickname, avatar: profile.avatar };
+          }),
+        }));
+      });
+    }
+  }
+}

--- a/im_web/src/lib/mock-data.ts
+++ b/im_web/src/lib/mock-data.ts
@@ -20,6 +20,8 @@ export interface Message {
   type: 'text' | 'image' | 'voice' | 'system';
   imageUrl?: string;
   replyTo?: { senderName: string; content: string };
+  /** 发送状态: sending=发送中, sent=已发送, failed=发送失败 */
+  status?: 'sending' | 'sent' | 'failed';
 }
 
 export interface Conversation {

--- a/im_web/src/lib/ws-client.ts
+++ b/im_web/src/lib/ws-client.ts
@@ -1,0 +1,362 @@
+/**
+ * WebSocket IM Client — RigorAck 三次通信协议
+ *
+ * 对接后端 apps/im/ws 的完整协议实现:
+ *   1. 客户端发送消息 (ackSeq=0, frameType=0x0 FrameData)
+ *   2. 服务端回 ACK   (ackSeq=1, frameType=0x3 FrameAck)
+ *   3. 客户端确认 ACK (ackSeq=2, frameType=0x3 FrameAck) → 服务端处理业务
+ */
+
+// ========== 帧类型 (与后端 message.go 对应) ==========
+export const FrameType = {
+  Data: 0x0,
+  Ping: 0x1,
+  Err: 0x2,
+  Ack: 0x3,
+  NoAck: 0x4,
+  CAck: 0x5,
+} as const;
+
+// ========== 消息类型 (与后端 constants/im.go 对应) ==========
+export const MsgType = {
+  Text: 1,
+  File: 2,
+  Voice: 3,
+  Image: 4,
+  Memes: 5,
+} as const;
+
+// ========== 聊天类型 ==========
+export const ChatType = {
+  Single: 1,
+  Group: 2,
+} as const;
+
+// ========== TypeScript 接口 ==========
+
+/** 后端 Message 结构 (message.go) */
+export interface WsMessage {
+  id: string;
+  ackSeq?: number;
+  frameType: number;
+  method?: string;
+  userId?: string;
+  formId?: string;
+  data?: unknown;
+}
+
+/** 后端 ws.Chat 数据结构 (ws.go) */
+export interface WsChatData {
+  conversationId: string;
+  chatType: number;
+  sendId: string;
+  recvId: string;
+  sendTime: number;
+  msg: {
+    mType: number;
+    content: string;
+    readRecords?: Record<string, string>;
+  };
+}
+
+/** 后端 ws.MarkRead 数据结构 */
+export interface WsMarkReadData {
+  chatType: number;
+  recvId: string;
+  conversationId: string;
+  sendId: string;
+  msgIds: string[];
+  readRecords: Record<string, string>;
+}
+
+type ConnState = 'disconnected' | 'connecting' | 'connected';
+type MessageHandler = (data: unknown, raw: WsMessage) => void;
+
+interface PendingAck {
+  resolve: () => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface IMWebSocketOptions {
+  url?: string;
+  token?: string;
+  ackTimeout?: number;
+  heartbeatInterval?: number;
+  reconnect?: boolean;
+  reconnectInterval?: number;
+  reconnectMaxRetries?: number;
+  onStateChange?: (state: ConnState, prev: ConnState) => void;
+  onError?: (err: unknown) => void;
+}
+
+// ========== 唯一 ID 生成 ==========
+let _seq = 0;
+function genMsgId(): string {
+  return `msg_${Date.now()}_${++_seq}`;
+}
+
+// ========== 主类 ==========
+
+export class IMWebSocket {
+  private url: string;
+  private token: string;
+  private ws: WebSocket | null = null;
+  private state: ConnState = 'disconnected';
+
+  // RigorAck
+  private pendingAck = new Map<string, PendingAck>();
+  private ackTimeout: number;
+
+  // 心跳
+  private heartbeatInterval: number;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  // 重连
+  private reconnectEnabled: boolean;
+  private reconnectInterval: number;
+  private reconnectMaxRetries: number;
+  private reconnectRetries = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private manualClose = false;
+
+  // 事件
+  private handlers = new Map<string, MessageHandler>();
+  private onStateChange: IMWebSocketOptions['onStateChange'];
+  private onError: IMWebSocketOptions['onError'];
+
+  constructor(opts: IMWebSocketOptions = {}) {
+    this.url = opts.url || 'ws://localhost:10090/ws';
+    this.token = opts.token || '';
+    this.ackTimeout = opts.ackTimeout || 30_000;
+    this.heartbeatInterval = opts.heartbeatInterval || 20_000;
+    this.reconnectEnabled = opts.reconnect !== false;
+    this.reconnectInterval = opts.reconnectInterval || 3_000;
+    this.reconnectMaxRetries = opts.reconnectMaxRetries || 10;
+    this.onStateChange = opts.onStateChange;
+    this.onError = opts.onError;
+  }
+
+  // ===================== Public API =====================
+
+  connect(token?: string) {
+    if (token) this.token = token;
+    if (!this.token) { console.error('[WS] missing token'); return; }
+    if (this.state !== 'disconnected') return;
+
+    this.manualClose = false;
+    this.setState('connecting');
+
+    try {
+      const wsUrl = `${this.url}?token=${encodeURIComponent(this.token)}`;
+      this.ws = new WebSocket(wsUrl);
+      this.ws.onopen = () => this.handleOpen();
+      this.ws.onmessage = (e) => this.handleMessage(e);
+      this.ws.onclose = (e) => this.handleClose(e);
+      this.ws.onerror = (e) => { this.onError?.(e); };
+    } catch (err) {
+      console.error('[WS] connect error:', err);
+      this.setState('disconnected');
+    }
+  }
+
+  disconnect() {
+    this.manualClose = true;
+    this.stopHeartbeat();
+    this.clearReconnect();
+    this.rejectAllPending('连接已关闭');
+    this.ws?.close();
+    this.ws = null;
+    this.setState('disconnected');
+  }
+
+  /** 注册消息 handler (method → handler) */
+  on(method: string, handler: MessageHandler) {
+    this.handlers.set(method, handler);
+  }
+
+  off(method: string) {
+    this.handlers.delete(method);
+  }
+
+  /** 发送业务消息 (RigorAck 三次通信)，Promise 在 ACK 完成后 resolve */
+  send(method: string, data: unknown): Promise<void> {
+    const id = genMsgId();
+    const msg: WsMessage = {
+      id,
+      ackSeq: 0,
+      frameType: FrameType.Data,
+      method,
+      data,
+    };
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingAck.delete(id);
+        reject(new Error(`ACK 超时: ${id}`));
+      }, this.ackTimeout);
+
+      this.pendingAck.set(id, { resolve, reject, timer });
+
+      if (!this.sendRaw(msg)) {
+        clearTimeout(timer);
+        this.pendingAck.delete(id);
+        reject(new Error('发送失败: 连接未建立'));
+      }
+    });
+  }
+
+  /** 发送不走 ACK 的消息 (心跳 / NoAck) */
+  sendNoAck(method: string, data?: unknown) {
+    this.sendRaw({
+      id: genMsgId(),
+      frameType: FrameType.NoAck,
+      method,
+      data: data ?? {},
+    });
+  }
+
+  get connected() { return this.state === 'connected'; }
+  get currentState() { return this.state; }
+
+  // ===================== 内部 =====================
+
+  private sendRaw(msg: WsMessage): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
+    try {
+      this.ws.send(JSON.stringify(msg));
+      return true;
+    } catch { return false; }
+  }
+
+  private setState(s: ConnState) {
+    const prev = this.state;
+    this.state = s;
+    if (prev !== s) this.onStateChange?.(s, prev);
+  }
+
+  // ---------- WebSocket 事件 ----------
+
+  private handleOpen() {
+    this.setState('connected');
+    this.reconnectRetries = 0;
+    this.startHeartbeat();
+  }
+
+  private handleMessage(event: MessageEvent) {
+    let msg: WsMessage;
+    try { msg = JSON.parse(event.data); } catch { return; }
+
+    switch (msg.frameType) {
+      case FrameType.Ack:
+        this.handleAck(msg);
+        break;
+      case FrameType.Err:
+        console.error('[WS] server error:', msg.data);
+        this.onError?.(msg.data);
+        break;
+      case FrameType.Data:
+      case FrameType.NoAck:
+        this.routeMessage(msg);
+        break;
+      // FramePing: 忽略（服务端不会主动发 FramePing）
+    }
+  }
+
+  private handleClose(_event: CloseEvent) {
+    this.stopHeartbeat();
+    this.rejectAllPending('连接断开');
+    this.setState('disconnected');
+    if (!this.manualClose && this.reconnectEnabled) {
+      this.scheduleReconnect();
+    }
+  }
+
+  // ---------- RigorAck ----------
+
+  /**
+   * 收到服务端 ACK (ackSeq=1) → 回复 ackSeq=2 完成三次握手
+   *
+   * 后端 server.go readAck():
+   *   message.AckSeq == 0 → AckSeq++ → 发回 {ackSeq:1, FrameAck}
+   *   等待客户端 msgSeq.AckSeq > message.AckSeq → 处理业务
+   */
+  private handleAck(msg: WsMessage) {
+    const pending = this.pendingAck.get(msg.id);
+    if (!pending) return; // 超时后到达的 ACK 或重发
+
+    if ((msg.ackSeq ?? 0) > 0) {
+      // 第三步：客户端确认
+      this.sendRaw({
+        id: msg.id,
+        ackSeq: (msg.ackSeq ?? 0) + 1,
+        frameType: FrameType.Ack,
+      });
+      clearTimeout(pending.timer);
+      this.pendingAck.delete(msg.id);
+      pending.resolve();
+    }
+  }
+
+  // ---------- 消息路由 ----------
+
+  private routeMessage(msg: WsMessage) {
+    const method = msg.method || '';
+    const handler = this.handlers.get(method);
+    if (handler) {
+      try { handler(msg.data, msg); } catch (e) { console.error(`[WS] handler "${method}" error:`, e); }
+    }
+  }
+
+  // ---------- 心跳 ----------
+
+  private startHeartbeat() {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.state === 'connected') this.sendNoAck('chat.ping');
+    }, this.heartbeatInterval);
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatTimer) { clearInterval(this.heartbeatTimer); this.heartbeatTimer = null; }
+  }
+
+  // ---------- 重连 ----------
+
+  private scheduleReconnect() {
+    if (this.reconnectRetries >= this.reconnectMaxRetries) return;
+    this.reconnectRetries++;
+    const delay = Math.min(this.reconnectInterval * 2 ** (this.reconnectRetries - 1), 30_000);
+    this.reconnectTimer = setTimeout(() => this.connect(), delay);
+  }
+
+  private clearReconnect() {
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    this.reconnectRetries = 0;
+  }
+
+  // ---------- 清理 ----------
+
+  private rejectAllPending(reason: string) {
+    for (const [, p] of this.pendingAck) {
+      clearTimeout(p.timer);
+      p.reject(new Error(reason));
+    }
+    this.pendingAck.clear();
+  }
+}
+
+// ========== 单例 ==========
+
+let _inst: IMWebSocket | null = null;
+
+export function getIMWs(): IMWebSocket {
+  if (!_inst) _inst = new IMWebSocket();
+  return _inst;
+}
+
+export function createIMWs(opts: IMWebSocketOptions): IMWebSocket {
+  _inst?.disconnect();
+  _inst = new IMWebSocket(opts);
+  return _inst;
+}


### PR DESCRIPTION
Backend changes:
- ws/ws.go: add json tags to all structs for correct JSON serialization
- auth.go: support JWT token via URL query param for browser WebSocket
- server.go: allow CORS in WebSocket upgrader, reduce readAck polling from 3s to 100ms
- push/pusher.go: populate ChatType field in push messages
- getchatloglogic.go: msgId as cursor for pagination instead of exact match
- getconversationslogic.go: filter out isShow=false conversations
- types.go: add form/optional tags for GET params, optional tags for PUT body

Frontend changes (im_web):
- New ws-client.ts: WebSocket client with RigorAck 3-way handshake, heartbeat, auto-reconnect
- New chat-store.ts: Zustand store for conversations, messages, WS lifecycle, user profile cache
- api-client.ts: add IM service (port 8890) fetch functions with typed helpers
- page.tsx: init WebSocket + fetch friends/conversations on login
- ChatDetail.tsx: real message send/receive via WS, scroll-to-top history loading, send status indicator, peer profile card by ID match
- ChatList.tsx: real conversation data, right-click context menu (pin/mute/delete), avatar image support
- ContactDetailPanel.tsx: send message creates real conversation via API
- GroupList.tsx: send message opens real chat for groups and members
- ForwardDialog.tsx: use real conversation list for forwarding
- Remove all mock data fallbacks from chat components