### PR TITLE
refactor(im): split recall events into a dedicated mq topic

### DIFF
--- a/apps/im/api/etc/im-dev.yaml
+++ b/apps/im/api/etc/im-dev.yaml
@@ -19,9 +19,9 @@ ImRpc:
   NonBlock: true
   Timeout: 10000
 
-# 撤回事件推送复用的 Kafka topic（与 ws/mq 一致）
-MsgChatTransfer:
-  Topic: msgChatTransfer
+# 撤回事件专用的 Kafka topic（与 mq 消费端一致）
+MsgRecallTransfer:
+  Topic: msgRecallTransfer
   Addrs:
     - 127.0.0.1:9092
 

--- a/apps/im/api/etc/im-sample.yaml
+++ b/apps/im/api/etc/im-sample.yaml
@@ -22,9 +22,9 @@ ImRpc:
       - 127.0.0.1:2379
     Key: im.rpc
 
-# 撤回事件推送复用的 Kafka topic（与 ws/mq 一致）
-MsgChatTransfer:
-  Topic: msgChatTransfer
+# 撤回事件专用的 Kafka topic（与 mq 消费端一致）
+MsgRecallTransfer:
+  Topic: msgRecallTransfer
   Addrs:
     - 127.0.0.1:9092
 

--- a/apps/im/api/internal/config/config.go
+++ b/apps/im/api/internal/config/config.go
@@ -18,8 +18,8 @@ type Config struct {
 
 	ImRpc zrpc.RpcClientConf
 
-	// MsgChatTransfer 撤回事件复用的消息推送 Kafka topic（生产端）
-	MsgChatTransfer struct {
+	// MsgRecallTransfer 撤回事件专用的 Kafka topic（生产端）
+	MsgRecallTransfer struct {
 		Addrs []string
 		Topic string
 	}

--- a/apps/im/api/internal/logic/recallmsglogic.go
+++ b/apps/im/api/internal/logic/recallmsglogic.go
@@ -30,7 +30,7 @@ func NewRecallMsgLogic(ctx context.Context, svcCtx *svc.ServiceContext) *RecallM
 }
 
 // RecallMsg 编排：调 im-rpc 完成校验+撤回（业务在 rpc），成功且本次真正翻转时，
-// 向通用 MsgChatTransfer 链路投递一条 ContentRecall 控制帧做推送（状态变更与推送副作用分离）。
+// 向撤回专用 MsgRecallTransfer 链路投递一条撤回事件做推送（状态变更与推送副作用分离）。
 func (l *RecallMsgLogic) RecallMsg(req *types.RecallMsgReq) (resp *types.RecallMsgResp, err error) {
 	uid := l.ctx.Value(Identify).(string)
 
@@ -55,17 +55,15 @@ func (l *RecallMsgLogic) RecallMsg(req *types.RecallMsgReq) (resp *types.RecallM
 	return &types.RecallMsgResp{}, nil
 }
 
-// publishRecall 复用 MsgChatTransfer 通用 topic，以 ContentRecall 控制帧下发；
-// 路由沿用原消息的 SendId/RecvId/ChatType，消费端据 MsgType 分流（跳过落库，仅扇出）。
+// publishRecall 向撤回专用 topic 投递撤回事件；路由沿用原消息的 SendId/RecvId/ChatType，
+// 消费端据此翻译成 ContentRecall 控制帧扇出（不落库，仅推送）。
 func (l *RecallMsgLogic) publishRecall(req *types.RecallMsgReq, rpcResp *im.RecallMsgResp) error {
-	return l.svcCtx.MsgChatTransferClient.Push(&mq.MsgChatTransfer{
+	return l.svcCtx.MsgRecallTransferClient.Push(&mq.MsgRecallTransfer{
 		ChatType:       constants.ChatType(req.ChatType),
 		ConversationId: req.ConversationId,
 		SendId:         rpcResp.SendId,
 		RecvId:         rpcResp.RecvId,
 		MsgId:          req.MsgId,
-		MsgType:        constants.ContentRecall,
-		ContentType:    constants.ContentRecall,
 		RecalledBy:     rpcResp.RecalledBy,
 	})
 }

--- a/apps/im/api/internal/svc/servicecontext.go
+++ b/apps/im/api/internal/svc/servicecontext.go
@@ -18,8 +18,8 @@ type ServiceContext struct {
 	User   userclient.User
 	IM     imclient.Im
 
-	// 撤回事件推送生产者（复用 MsgChatTransfer 通用链路）
-	MsgChatTransferClient mq_client.MsgChatTransferClient
+	// 撤回事件推送生产者（独立 msgRecallTransfer topic）
+	MsgRecallTransferClient mq_client.MsgRecallTransferClient
 
 	FileStorage storage.FileStorage
 }
@@ -39,7 +39,7 @@ func NewServiceContext(c config.Config) *ServiceContext {
 		Social:                socialclient.NewSocial(zrpc.MustNewClient(c.SocialRpc)),
 		User:                  userclient.NewUser(zrpc.MustNewClient(c.UserRpc)),
 		IM:                    imclient.NewIm(zrpc.MustNewClient(c.ImRpc)),
-		MsgChatTransferClient: mq_client.NewMsgChatTransferClient(c.MsgChatTransfer.Addrs, c.MsgChatTransfer.Topic),
+		MsgRecallTransferClient: mq_client.NewMsgRecallTransferClient(c.MsgRecallTransfer.Addrs, c.MsgRecallTransfer.Topic),
 		FileStorage:           storage.NewLocalStorage(basePath, baseURL),
 	}
 }

--- a/apps/task/mq/etc/mq-dev.yaml
+++ b/apps/task/mq/etc/mq-dev.yaml
@@ -26,6 +26,15 @@ MsgReadTransfer:
   Offset: first
   Consumers: 1
 
+MsgRecallTransfer:
+  Name: msgRecallTrans
+  Brokers:
+    - 127.0.0.1:9092
+  Group: kafka
+  Topic: msgRecallTransfer
+  Offset: first
+  Consumers: 1
+
 Ws:
   Host: 127.0.0.1:10090
 

--- a/apps/task/mq/etc/mq-sample.yaml
+++ b/apps/task/mq/etc/mq-sample.yaml
@@ -26,6 +26,15 @@ MsgReadTransfer:
   Offset: first
   Consumers: 1
 
+MsgRecallTransfer:
+  Name: msgRecallTrans
+  Brokers:
+    - 127.0.0.1:9092
+  Group: kafka
+  Topic: msgRecallTransfer
+  Offset: first
+  Consumers: 1
+
 Ws:
   Host: 127.0.0.1:10090
 

--- a/apps/task/mq/internal/config/config.go
+++ b/apps/task/mq/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 
 	MsgReadTransfer kq.KqConf
 
+	MsgRecallTransfer kq.KqConf
+
 	Ws struct {
 		Host string
 	}

--- a/apps/task/mq/internal/handler/listen.go
+++ b/apps/task/mq/internal/handler/listen.go
@@ -24,9 +24,11 @@ func (l *Listen) Services() []service.Service {
 	// NewMsgChatTransfer 结构体实现了 kq.ConsumeHandle接口
 	msgChatConsumeHandle := msgTransfer.NewMsgChatTransfer(l.svc)
 	msgChatMarkReadConsumeHandle := msgTransfer.NewMsgReadTransfer(l.svc)
+	msgRecallConsumeHandle := msgTransfer.NewMsgRecallTransfer(l.svc)
 	// 注册处理逻辑
 	return []service.Service{
 		kq.MustNewQueue(l.svc.Config.MsgChatTransfer, msgChatConsumeHandle),
 		kq.MustNewQueue(l.svc.Config.MsgReadTransfer, msgChatMarkReadConsumeHandle),
+		kq.MustNewQueue(l.svc.Config.MsgRecallTransfer, msgRecallConsumeHandle),
 	}
 }

--- a/apps/task/mq/internal/handler/msg_transfer/msg_chat_transfer.go
+++ b/apps/task/mq/internal/handler/msg_transfer/msg_chat_transfer.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	model "github.com/iceymoss/go-hichat-api/apps/im/models"
-	"github.com/iceymoss/go-hichat-api/apps/im/ws/websocket"
 	"github.com/iceymoss/go-hichat-api/apps/social/rpc/socialclient"
 	"github.com/iceymoss/go-hichat-api/apps/task/mq/internal/svc"
 	"github.com/iceymoss/go-hichat-api/apps/task/mq/mq"
@@ -45,11 +44,6 @@ func (m *MsgChatTransfer) Consume(ctx context.Context, key, value string) error 
 
 	fmt.Printf("已经收到消息了: %+v\n", data)
 
-	// 撤回控制帧：DB 已由 im-rpc 更新，这里不落库，仅复用通用 fan-out 推送给会话各端。
-	if data.MsgType == constants.ContentRecall {
-		return m.transferRecall(ctx, &data)
-	}
-
 	// 写入数据库（如 MongoDB 聊天记录）；同时把真实 MsgId 回填到 data，供下游推送
 	if err = m.addChatLog(ctx, &data); err != nil {
 		return err
@@ -61,29 +55,6 @@ func (m *MsgChatTransfer) Consume(ctx context.Context, key, value string) error 
 	}
 	// 2) 额外回响给发送方：携带 MongoDB MsgId，前端把 local_ 占位 ID 升级为真实 ID
 	return m.echoToSender(&data)
-}
-
-// transferRecall 推送撤回事件给会话各端：
-// 先按会话成员扇出（group 跳过原发送者 / single 推给对端），再单独补推给原发送者本人（含其它在线设备）。
-// 全程不改写 ContentType，保持前端能识别 ContentRecall。撤回幂等，重复推送无副作用。
-func (m *MsgChatTransfer) transferRecall(ctx context.Context, data *mq.MsgChatTransfer) error {
-	if err := m.MsgChatTransfer(ctx, data); err != nil {
-		return err
-	}
-	if data.SendId == "" {
-		return nil
-	}
-	// 补推给原发送者本人：走 single 路径（pusher 会 push 到 RecvId），不改 ContentType。
-	echo := *data
-	echo.RecvIdList = nil
-	echo.RecvId = data.SendId
-	echo.ChatType = constants.SingleChatType
-	return m.svcCtx.WsClient.Send(websocket.Message{
-		FrameType: websocket.FrameNoAck,
-		Method:    "push",
-		FormId:    constants.SYSTEM_ROOT_UID,
-		Data:      &echo,
-	})
 }
 
 // addChatLog 将聊天记录消息持久化到数据库中
@@ -193,38 +164,4 @@ func (m *MsgChatTransfer) markAtMe(ctx context.Context, data *mq.MsgChatTransfer
 			zLog.Error("markAtMe: update conversations failed", zap.Error(err), zap.String("uid", uid))
 		}
 	}
-}
-
-func (m *MsgChatTransfer) single(ctx context.Context, data *mq.MsgChatTransfer) error {
-	return m.svcCtx.WsClient.Send(websocket.Message{
-		FrameType: websocket.FrameNoAck,
-		Method:    "push",
-		FormId:    constants.SYSTEM_ROOT_UID,
-		Data:      data,
-	})
-}
-
-func (m *MsgChatTransfer) group(ctx context.Context, data *mq.MsgChatTransfer) error {
-	res, err := m.svcCtx.Social.GroupUsers(ctx, &socialclient.GroupUsersReq{
-		GroupId: data.RecvId,
-	})
-	if err != nil {
-		return err
-	}
-
-	data.RecvIdList = make([]string, 0, len(res.List))
-	for _, member := range res.List {
-		// 跳过发送人
-		if member.UserId == data.SendId {
-			continue
-		}
-		data.RecvIdList = append(data.RecvIdList, member.UserId)
-	}
-
-	return m.svcCtx.WsClient.Send(websocket.Message{
-		FrameType: websocket.FrameNoAck,
-		Method:    "push",
-		FormId:    constants.SYSTEM_ROOT_UID,
-		Data:      data,
-	})
 }

--- a/apps/task/mq/internal/handler/msg_transfer/msg_recall_transfer.go
+++ b/apps/task/mq/internal/handler/msg_transfer/msg_recall_transfer.go
@@ -1,0 +1,66 @@
+package msg_transfer
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/iceymoss/go-hichat-api/apps/im/ws/websocket"
+	"github.com/iceymoss/go-hichat-api/apps/task/mq/internal/svc"
+	"github.com/iceymoss/go-hichat-api/apps/task/mq/mq"
+	"github.com/iceymoss/go-hichat-api/pkg/constants"
+
+	"github.com/zeromicro/go-queue/kq"
+)
+
+// MsgRecallTransfer 撤回事件消费者，实现 ConsumeHandler 接口。
+// 撤回走独立 topic（msgRecallTransfer），与普通聊天消息解耦；
+// DB 已由 im-rpc 更新，这里不落库，仅把撤回翻译成 ContentRecall 控制帧扇出给会话各端。
+type MsgRecallTransfer struct {
+	*BaseChatTransfer
+}
+
+// NewMsgRecallTransfer 实例化一个 MsgRecallTransfer
+func NewMsgRecallTransfer(svc *svc.ServiceContext) kq.ConsumeHandler {
+	return &MsgRecallTransfer{
+		BaseChatTransfer: NewBaseMsgChatTransfer(svc),
+	}
+}
+
+func (m *MsgRecallTransfer) Consume(ctx context.Context, key, value string) error {
+	var in mq.MsgRecallTransfer
+	if err := json.Unmarshal([]byte(value), &in); err != nil {
+		return err
+	}
+
+	// 翻译成通用推送帧：保持 ContentRecall（mType=9），前端协议与原先逐字段一致。
+	data := &mq.MsgChatTransfer{
+		ChatType:       in.ChatType,
+		ConversationId: in.ConversationId,
+		SendId:         in.SendId,
+		RecvId:         in.RecvId,
+		MsgId:          in.MsgId,
+		MsgType:        constants.ContentRecall,
+		ContentType:    constants.ContentRecall,
+		RecalledBy:     in.RecalledBy,
+	}
+
+	// 先按会话成员扇出（group 跳过原发送者 / single 推给对端），
+	// 再单独补推给原发送者本人（含其它在线设备）。撤回幂等，重复推送无副作用。
+	if err := m.MsgChatTransfer(ctx, data); err != nil {
+		return err
+	}
+	if data.SendId == "" {
+		return nil
+	}
+	// 补推给原发送者本人：走 single 路径（pusher 会 push 到 RecvId），不改 ContentType。
+	echo := *data
+	echo.RecvIdList = nil
+	echo.RecvId = data.SendId
+	echo.ChatType = constants.SingleChatType
+	return m.svcCtx.WsClient.Send(websocket.Message{
+		FrameType: websocket.FrameNoAck,
+		Method:    "push",
+		FormId:    constants.SYSTEM_ROOT_UID,
+		Data:      &echo,
+	})
+}

--- a/apps/task/mq/mq/mq.go
+++ b/apps/task/mq/mq/mq.go
@@ -44,6 +44,25 @@ type MsgChatTransfer struct {
 	AtAll bool `json:"atAll,omitempty"`
 }
 
+// MsgRecallTransfer 撤回事件消息结构体。
+// 撤回与普通聊天消息是两类语义不同的领域事件，走独立 topic（msgRecallTransfer），
+// 消费端据此扇出撤回控制帧，避免与聊天消息共享通道造成的领域耦合与吞吐相互影响。
+// 注意：仅承载撤回所需字段；推送给前端的帧仍由消费端翻译成 ContentRecall 控制帧，对外协议不变。
+type MsgRecallTransfer struct {
+	// 消息类型：1. 私聊、2. 群聊
+	ChatType constants.ChatType `json:"chatType"`
+	// 会话id
+	ConversationId string `json:"conversationId"`
+	// 原消息发送者
+	SendId string `json:"sendId"`
+	// 原消息接收者（私聊为对端 uid，群聊为群 id）
+	RecvId string `json:"recvId"`
+	// 被撤回的消息 ID
+	MsgId string `json:"msgId"`
+	// RecalledBy 撤回操作者 uid
+	RecalledBy string `json:"recalledBy"`
+}
+
 // MsgMarkRead 标记已读消息结构体
 type MsgMarkRead struct {
 	// 消息类型：1. 私聊、2. 群聊

--- a/apps/task/mq/mq_client/msg_recall_client.go
+++ b/apps/task/mq/mq_client/msg_recall_client.go
@@ -1,0 +1,37 @@
+package mq_client
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/iceymoss/go-hichat-api/apps/task/mq/mq"
+
+	"github.com/zeromicro/go-queue/kq"
+)
+
+type MsgRecallTransferClient interface {
+	Push(msg *mq.MsgRecallTransfer) error
+}
+
+type msgRecallTransferClient struct {
+	pusher *kq.Pusher
+}
+
+// NewMsgRecallTransferClient 通过配置实例化撤回事件生产者
+func NewMsgRecallTransferClient(addr []string, topic string, opts ...kq.PushOption) MsgRecallTransferClient {
+	return &msgRecallTransferClient{
+		pusher: kq.NewPusher(addr, topic, opts...),
+	}
+}
+
+// Push 将撤回事件 push 到 kafka 中
+func (c *msgRecallTransferClient) Push(msg *mq.MsgRecallTransfer) error {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	return c.pusher.Push(ctx, string(body))
+}


### PR DESCRIPTION
Recall events previously reused the chat message topic (msgChatTransfer) and were demuxed on the consumer side by MsgType==ContentRecall. This coupled two distinct domain events onto one channel, forcing the chat consumer to know about recall semantics and making recall share Kafka partition/ordering/throughput with normal messages.

Introduce a dedicated msgRecallTransfer topic with its own producer client (MsgRecallTransferClient), MQ struct (MsgRecallTransfer) and consumer (MsgRecallTransfer), mirroring the existing msgReadTransfer precedent. The consumer translates the recall event back into a ContentRecall control frame for fan-out, so the WS frames seen by the frontend and the DB state are byte-for-byte unchanged — this is a purely internal transport change.

Also drop the now-dead duplicate single/group methods on MsgChatTransfer (shadowed by BaseChatTransfer, never dispatched) and the unused MsgChatTransfer producer wiring in im/api.