### PR TITLE
feat: add image preview lightbox for trend images

### DIFF
--- a/web/src/components/im/ImageViewer.tsx
+++ b/web/src/components/im/ImageViewer.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useCallback, useEffect } from 'react';
+import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface ImageViewerProps {
+  images: string[];
+  /** Index of the image currently shown. < 0 means the viewer is closed. */
+  index: number;
+  onClose: () => void;
+  onIndexChange: (index: number) => void;
+}
+
+/**
+ * Fullscreen image lightbox. Enlarges the clicked image and, when a trend has
+ * multiple images, supports 上一张 / 下一张 navigation (wrap-around), a counter,
+ * and keyboard control (Esc to close, ←/→ to switch).
+ */
+export default function ImageViewer({ images, index, onClose, onIndexChange }: ImageViewerProps) {
+  const open = index >= 0 && index < images.length;
+  const multiple = images.length > 1;
+
+  const goPrev = useCallback(() => {
+    onIndexChange((index - 1 + images.length) % images.length);
+  }, [index, images.length, onIndexChange]);
+
+  const goNext = useCallback(() => {
+    onIndexChange((index + 1) % images.length);
+  }, [index, images.length, onIndexChange]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      else if (e.key === 'ArrowLeft' && multiple) goPrev();
+      else if (e.key === 'ArrowRight' && multiple) goNext();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, multiple, goPrev, goNext, onClose]);
+
+  if (!open) return null;
+
+  const arrowStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    width: 44,
+    height: 44,
+    borderRadius: '50%',
+    border: 'none',
+    background: 'rgba(0,0,0,0.4)',
+    color: '#FFF',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  return (
+    <div
+      className="fixed inset-0"
+      style={{ zIndex: 10010, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.9)' }}
+      onClick={onClose}
+    >
+      {/* Close */}
+      <button
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        style={{ position: 'absolute', top: 20, right: 20, width: 40, height: 40, borderRadius: '50%', border: 'none', background: 'rgba(0,0,0,0.4)', color: '#FFF', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <X className="w-5 h-5" />
+      </button>
+
+      {/* Counter */}
+      {multiple && (
+        <div style={{ position: 'absolute', top: 24, left: '50%', transform: 'translateX(-50%)', fontSize: 14, color: '#FFF', background: 'rgba(0,0,0,0.4)', borderRadius: 14, padding: '4px 14px' }}>
+          {index + 1} / {images.length}
+        </div>
+      )}
+
+      {/* Prev */}
+      {multiple && (
+        <button onClick={(e) => { e.stopPropagation(); goPrev(); }} style={{ ...arrowStyle, left: 20 }}>
+          <ChevronLeft className="w-6 h-6" />
+        </button>
+      )}
+
+      {/* Image */}
+      <img
+        src={images[index]}
+        alt=""
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '90vw', maxHeight: '90vh', objectFit: 'contain', display: 'block', borderRadius: 4 }}
+      />
+
+      {/* Next */}
+      {multiple && (
+        <button onClick={(e) => { e.stopPropagation(); goNext(); }} style={{ ...arrowStyle, right: 20 }}>
+          <ChevronRight className="w-6 h-6" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/im/MomentsFeed.tsx
+++ b/web/src/components/im/MomentsFeed.tsx
@@ -34,6 +34,7 @@ import {
   ImagePlus,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import ImageViewer from './ImageViewer';
 import { getAvatarColor } from '@/lib/utils';
 import { useIMStore } from '@/lib/im-store';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -297,6 +298,7 @@ function TrendCard({
 }: TrendCardProps) {
   const [likeAnim, setLikeAnim] = useState(false);
   const [likeNamesExpanded, setLikeNamesExpanded] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(-1);
   const showUserCard = useIMStore(s => s.showUserCard);
   const userName = trendDisplayName(trend);
   const userAvatar = trend.userAvatar || '';
@@ -400,6 +402,7 @@ function TrendCard({
                   key={idx}
                   className="overflow-hidden cursor-pointer"
                   style={{ borderRadius: 6, background: '#E8EDEF', aspectSquare: trend.resources.length > 1 ? 'auto' : undefined, maxHeight: trend.resources.length === 1 ? 200 : undefined }}
+                  onClick={(e) => { e.stopPropagation(); setViewerIndex(idx); }}
                 >
                   <img src={img} alt="" className="w-full h-full object-cover hover:scale-105 transition-transform duration-200" style={{ display: 'block', ...(trend.resources.length === 1 ? { height: 200 } : { aspectRatio: '1' }) }} />
                 </div>
@@ -602,6 +605,8 @@ function TrendCard({
           )}
         </div>
       </div>
+
+      <ImageViewer images={trend.resources} index={viewerIndex} onClose={() => setViewerIndex(-1)} onIndexChange={setViewerIndex} />
     </div>
   );
 }
@@ -1031,6 +1036,7 @@ function TrendDetailModal({
   onToggleLike, onLikeCountClick, onSubmitComment, onCommentTextChange,
   onSetReplyTarget, onDeleteComment, onAvatarClick, onClose,
 }: TrendDetailModalProps) {
+  const [viewerIndex, setViewerIndex] = useState(-1);
   if (!open || !trend) return null;
   const userName = trendDisplayName(trend);
   const userAvatar = trend.userAvatar || '';
@@ -1122,8 +1128,13 @@ function TrendDetailModal({
           {trend.type === 2 && trend.resources.length > 0 && (
             <div className={`grid ${imageGridClass(trend.resources.length)} gap-2 mb-4`} style={{ maxWidth: '100%' }}>
               {trend.resources.map((img, idx) => (
-                <div key={idx} className="overflow-hidden" style={{ borderRadius: 8, background: '#E8EDEF' }}>
-                  <img src={img} alt="" className="w-full object-cover" style={{ display: 'block', aspectRatio: trend.resources.length === 1 ? '16/9' : '1' }} />
+                <div
+                  key={idx}
+                  className="overflow-hidden cursor-pointer"
+                  style={{ borderRadius: 8, background: '#E8EDEF' }}
+                  onClick={() => setViewerIndex(idx)}
+                >
+                  <img src={img} alt="" className="w-full object-cover hover:scale-105 transition-transform duration-200" style={{ display: 'block', aspectRatio: trend.resources.length === 1 ? '16/9' : '1' }} />
                 </div>
               ))}
             </div>
@@ -1216,6 +1227,8 @@ function TrendDetailModal({
           </div>
         )}
       </div>
+
+      <ImageViewer images={trend.resources} index={viewerIndex} onClose={() => setViewerIndex(-1)} onIndexChange={setViewerIndex} />
     </div>
   );
 }

--- a/web/src/components/im/TrendDetailPanel.tsx
+++ b/web/src/components/im/TrendDetailPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from 'sonner';
 import { getAvatarColor } from '@/lib/utils';
 import { useIMStore } from '@/lib/im-store';
+import ImageViewer from './ImageViewer';
 import {
   type Trend,
   type TrendComment,
@@ -209,6 +210,7 @@ export default function TrendDetailPanel() {
   const [replyTarget, setReplyTarget] = useState<TrendComment | null>(null);
   const [likeAnim, setLikeAnim] = useState(false);
   const [likeExpanded, setLikeExpanded] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(-1);
 
   const likeCount = trend?.agreeCount || 0;
 
@@ -463,7 +465,12 @@ export default function TrendDetailPanel() {
             {trend.type === 2 && trend.resources.length > 0 && (
               <div className={`grid ${imageGridClass(trend.resources.length)} gap-2`} style={{ marginBottom: 12 }}>
                 {trend.resources.map((img, idx) => (
-                  <div key={idx} className="overflow-hidden" style={{ borderRadius: 8, background: '#E8EDEF' }}>
+                  <div
+                    key={idx}
+                    className="overflow-hidden cursor-pointer"
+                    style={{ borderRadius: 8, background: '#E8EDEF' }}
+                    onClick={() => setViewerIndex(idx)}
+                  >
                     <img
                       src={img}
                       alt=""
@@ -686,6 +693,8 @@ export default function TrendDetailPanel() {
           )}
         </div>
       )}
+
+      <ImageViewer images={trend.resources} index={viewerIndex} onClose={() => setViewerIndex(-1)} onIndexChange={setViewerIndex} />
     </div>
   );
 }


### PR DESCRIPTION
Add a reusable ImageViewer lightbox that enlarges trend images on click.
- Trend list (TrendCard): click an image to enlarge it
- Trend detail (TrendDetailModal & TrendDetailPanel): click to open with prev/next navigation across the trend's images
- Supports wrap-around nav, image counter, keyboard (Esc/arrows), and backdrop click to close