### PR TITLE
fix(web): keep app full-height when font-size zoom is applied

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -82,7 +82,10 @@ export default function Home() {
 
   return (
     <SettingsProvider>
-      <main className="h-dvh overflow-hidden">
+      {/* h-full so the app follows the zoom-compensated height of .hc-app
+          (SettingsProvider). Using h-dvh here would ignore that compensation and
+          leave a blank strip at the bottom when the font-size zoom is not 1. */}
+      <main className="h-full overflow-hidden">
         <IMLayout />
       </main>
     </SettingsProvider>

--- a/web/src/components/SettingsProvider.tsx
+++ b/web/src/components/SettingsProvider.tsx
@@ -44,7 +44,11 @@ export default function SettingsProvider({ children }: { children: React.ReactNo
       data-font-size={fontSize}
       data-lang={language}
       style={{
-        height: '100%',
+        // Compensate the height for `zoom`: zoom scales the 100dvh child too, so a
+        // scale < 1 would leave a blank strip at the bottom (and > 1 would overflow).
+        // calc(100dvh / scale) renders taller/shorter so that *after* zoom it is
+        // exactly one viewport tall. At scale 1 this is just 100dvh.
+        height: `calc(100dvh / ${fontScale})`,
         // Font size scaling via CSS zoom (affects everything including inline styles)
         zoom: fontScale !== 1 ? fontScale : undefined,
         // Dark mode via CSS filter (affects ALL colors including inline styles)


### PR DESCRIPTION
The .hc-app font-size scaling uses CSS zoom, which also scaled the 100dvh main element and left a blank strip at the bottom on the small font size. Compensate the container height with calc(100dvh / scale) and let main fill it.